### PR TITLE
Challenge viewer changes and support for archived challenges

### DIFF
--- a/projects/gameboard-ui/src/app/admin/challenge-browser/challenge-browser.component.html
+++ b/projects/gameboard-ui/src/app/admin/challenge-browser/challenge-browser.component.html
@@ -17,19 +17,39 @@
           <span>Search</span>
         </span>
       </div>
-      <input type="search" [(ngModel)]="search.term" placeholder="code" class="form-control" (input)="refresh$.next(true)">
+      <input type="search" [(ngModel)]="search.term" placeholder="term" class="form-control" (input)="refresh$.next(true)">
     </div>
-    <div *ngIf="source$ | async as list">
+    <div *ngIf="challenges$ | async as list">
+      <div class="mt-2 border-bottom">
+        <span>Current</span>
+      </div>
+      <ul class="list-unstyled mb-1">
+        <li *ngFor="let s of list; trackBy:trackById" class="row px-0 mx-0 clickable" 
+          [class]="s.id == selected?.id ? 'clicked' : ''" (click)="select(s)">
+          <div class="col-1 px-1 align-self-center">
+            <fa-icon *ngIf="s.isActive" class="small text-success align-self-center" [icon]="faCircle"></fa-icon>
+          </div>
+          <span class="col mr-2 px-1 align-self-center">{{s.id | slice:0:8}}: {{s.tag}}</span>
+          <small class="col px-1 align-self-center">{{s.lastSyncTime | ago}}</small>
+        </li>
+      </ul>
+    </div>
+
+    <div *ngIf="archived$ | async as list">
+      <div class="mt-1 border-bottom">
+        <span>Archived</span>
+      </div>
       <ul class="list-unstyled">
-        <li *ngFor="let s of list; trackBy:trackById" class="clickable" (click)="select(s)">
-          <span class="mr-2">{{s.id | slice:0:8}} : {{s.tag}}</span>
-          <small>{{s.lastSyncTime | ago}}</small>
+        <li *ngFor="let s of list; trackBy:trackById" class="row px-0 mx-0 clickable" [class]="s.id == selected?.id ? 'clicked' : ''" 
+          (click)="select(s)">
+          <span class="col offset-1 mr-2 px-1 align-self-center">{{s.id | slice:0:8}}: {{s.tag}}</span>
+          <small class="col px-1 align-self-center">{{s.lastSyncTime | ago}}</small>
         </li>
       </ul>
     </div>
   </div>
 
-  <div class="detail p-4">
+  <div class="detail p-4 border border-dark rounded">
     <div *ngIf="selected">
 
       <app-error-div [errors]="errors"></app-error-div>

--- a/projects/gameboard-ui/src/app/admin/challenge-browser/challenge-browser.component.scss
+++ b/projects/gameboard-ui/src/app/admin/challenge-browser/challenge-browser.component.scss
@@ -1,3 +1,5 @@
+@import '../../../scss/variables';
+
 .fixed {
   height: 75vh;
   position: relative;
@@ -25,4 +27,19 @@
 }
 .clickable:hover {
   background-color: darkslategrey;
+}
+.clicked {
+  background-color: darken(darkslategrey, 5%);
+}
+
+// scroll bar to match theme
+::-webkit-scrollbar {
+  border-radius: 0.25rem;
+  background: $black; 
+}
+::-webkit-scrollbar-thumb {
+  background: $dark; 
+}
+::-webkit-scrollbar-thumb:hover {
+  background: darken($dark, 5%)
 }

--- a/projects/gameboard-ui/src/app/api/board-models.ts
+++ b/projects/gameboard-ui/src/app/api/board-models.ts
@@ -28,6 +28,7 @@ export interface ChallengeSummary {
   gameName: string;
   playerName: string;
   playerId: string;
+  userId: string;
   tag: string;
   startTime: Date;
   endTime: Date;
@@ -38,6 +39,18 @@ export interface ChallengeSummary {
   score: number;
   duration: number;
   result: ChallengeResult;
+  events: ChallengeEvent[];
+  teamMembers: string[];
+  isActive: boolean;
+  archived: boolean;
+  submissions: SectionSubmission[];
+}
+
+export interface ChallengeEvent {
+  userId: string;
+  text: string;
+  type: string;
+  timestamp: Date;
 }
 
 export interface NewChallenge {

--- a/projects/gameboard-ui/src/app/api/board.service.ts
+++ b/projects/gameboard-ui/src/app/api/board.service.ts
@@ -26,6 +26,9 @@ export class BoardService {
     return this.http.get<ChallengeSummary[]>(this.url + '/challenges', {params: filter});
   }
 
+  public archived(filter: any): Observable<ChallengeSummary[]> {
+    return this.http.get<ChallengeSummary[]>(this.url + '/challenges/archived', {params: filter});
+  }
   public load(id: string): Observable<BoardPlayer> {
     return this.http.get<BoardPlayer>(`${this.url}/board/${id}`).pipe(
       map(b => this.transform(b))


### PR DESCRIPTION
Corresponding API changes: https://github.com/cmu-sei/Gameboard/pull/32

- New "Archived" list of challenges under the normal "Current" list
- Green dot showing if current challenge is active  
- New models and api functions

This allows you to view archived and current challenges in the same support page. The search bar is for both types of records and can match several different properties like userId and challengeTag.