### PR TITLE
Enhanced countdown format and style

### DIFF
--- a/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.html
+++ b/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.html
@@ -19,8 +19,8 @@
       <div class="text-info card-text mb-2">
         <!-- <span *ngIf="game.isBefore">Game window opens in </span> -->
         <span *ngIf="ctx.session.isAfter">Game Over </span>
-        <span *ngIf="ctx.session.isDuring">Session ends in </span>
-        <span>{{ctx.session.countdown | countdown}}</span>
+        <span *ngIf="ctx.session.isDuring">Time Remaining: </span>
+        <span class="font-weight-bold" [class]="ctx.session.countdown | countdowncolor">{{ctx.session.countdown| countdown}}</span>
       </div>
       <table class="table mt-2 text-center">
         <tbody>

--- a/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.html
+++ b/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.html
@@ -20,7 +20,7 @@
         <!-- <span *ngIf="game.isBefore">Game window opens in </span> -->
         <span *ngIf="ctx.session.isAfter">Game Over </span>
         <span *ngIf="ctx.session.isDuring">Time Remaining: </span>
-        <span class="font-weight-bold" [class]="ctx.session.countdown | countdowncolor">{{ctx.session.countdown| countdown}}</span>
+        <span class="font-weight-bold" [class]="ctx.session.countdown | countdowncolor">{{ctx.session.countdown | countdown}}</span>
       </div>
       <table class="table mt-2 text-center">
         <tbody>

--- a/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.scss
+++ b/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.scss
@@ -29,3 +29,13 @@
   max-width: 300px;
   max-height: 300px;
 }
+
+.countdown-green {
+  color: rgb(0, 191, 0);
+}
+.countdown-yellow {
+  color: rgb(210, 210, 69);
+}
+.countdown-red {
+  color: rgb(211, 0, 0);
+}

--- a/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.scss
+++ b/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.scss
@@ -34,8 +34,8 @@
   color: rgb(0, 191, 0);
 }
 .countdown-yellow {
-  color: rgb(210, 210, 69);
+  color: rgb(236, 236, 130);
 }
 .countdown-red {
-  color: rgb(211, 0, 0);
+  color: rgb(255, 53, 53);
 }

--- a/projects/gameboard-ui/src/app/game/player-session/player-session.component.html
+++ b/projects/gameboard-ui/src/app/game/player-session/player-session.component.html
@@ -17,9 +17,9 @@
       <div class="card-title lead">
         <ng-container *ngIf="!ctx.player.session.isBefore">
           <div class="d-flex text-info card-text">
-            <span *ngIf="ctx.player.session.isDuring">Session ends in </span>
+            <span *ngIf="ctx.player.session.isDuring">Time Remaining: </span>
             <span *ngIf="ctx.player.session.isAfter">Session ended </span>
-            <span class="">&nbsp;{{ctx.player.session.countdown | countdown}}</span>
+            <span class="font-weight-bold" [class]="ctx.player.session.countdown | countdowncolor">&nbsp;{{ctx.player.session.countdown| countdown}}</span>
             <div class="spacer"></div>
             <app-confirm-button *ngIf="ctx.game.allowReset" class="mx-2"
               btnClass="btn btn-sm pop-warning" (confirm)="reset(ctx.player)">

--- a/projects/gameboard-ui/src/app/game/player-session/player-session.component.html
+++ b/projects/gameboard-ui/src/app/game/player-session/player-session.component.html
@@ -19,7 +19,7 @@
           <div class="d-flex text-info card-text">
             <span *ngIf="ctx.player.session.isDuring">Time Remaining: </span>
             <span *ngIf="ctx.player.session.isAfter">Session ended </span>
-            <span class="font-weight-bold" [class]="ctx.player.session.countdown | countdowncolor">&nbsp;{{ctx.player.session.countdown| countdown}}</span>
+            <span class="font-weight-bold" [class]="ctx.player.session.countdown | countdowncolor">&nbsp;{{ctx.player.session.countdown | countdown}}</span>
             <div class="spacer"></div>
             <app-confirm-button *ngIf="ctx.game.allowReset" class="mx-2"
               btnClass="btn btn-sm pop-warning" (confirm)="reset(ctx.player)">

--- a/projects/gameboard-ui/src/app/game/player-session/player-session.component.scss
+++ b/projects/gameboard-ui/src/app/game/player-session/player-session.component.scss
@@ -2,3 +2,13 @@
   max-width: 400px;
   margin: 0 auto;
 }
+
+.countdown-green {
+  color: rgb(0, 191, 0);
+}
+.countdown-yellow {
+  color: rgb(210, 210, 69);
+}
+.countdown-red {
+  color: rgb(211, 0, 0);
+}

--- a/projects/gameboard-ui/src/app/game/player-session/player-session.component.scss
+++ b/projects/gameboard-ui/src/app/game/player-session/player-session.component.scss
@@ -7,8 +7,8 @@
   color: rgb(0, 191, 0);
 }
 .countdown-yellow {
-  color: rgb(210, 210, 69);
+  color: rgb(236, 236, 130);
 }
 .countdown-red {
-  color: rgb(211, 0, 0);
+  color: rgb(255, 53, 53);
 }

--- a/projects/gameboard-ui/src/app/utility/config.service.ts
+++ b/projects/gameboard-ui/src/app/utility/config.service.ts
@@ -157,6 +157,7 @@ export interface Settings {
   imghost?: string;
   tochost?: string;
   tocfile?: string;
+  countdownStartSecondsAtMinute?: number;
   oidc: AppUserManagerSettings;
 }
 

--- a/projects/gameboard-ui/src/app/utility/pipes/countdown-color.pipe.spec.ts
+++ b/projects/gameboard-ui/src/app/utility/pipes/countdown-color.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { CountdownColorPipe } from './countdown-color.pipe';
+
+describe('CountdownColorPipe', () => {
+  it('create an instance', () => {
+    const pipe = new CountdownColorPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/projects/gameboard-ui/src/app/utility/pipes/countdown-color.pipe.ts
+++ b/projects/gameboard-ui/src/app/utility/pipes/countdown-color.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'countdowncolor'
+})
+export class CountdownColorPipe implements PipeTransform {
+
+  transform(value: number, ...args: unknown[]): string {
+    if (value >= (1000 * 60 * 60)) { // >= 1 hour
+      return "countdown-green";
+    } else if (value >= (1000 * 60 * 5)) { // < 1 hour and >= 5 min
+      return "countdown-yellow";
+    } else if (value != 0) {  // < 5 min and not 0 (game over)
+      return "countdown-red";
+    }
+    return "";
+  }
+
+}

--- a/projects/gameboard-ui/src/app/utility/pipes/countdown-color.pipe.ts
+++ b/projects/gameboard-ui/src/app/utility/pipes/countdown-color.pipe.ts
@@ -1,16 +1,25 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { ConfigService } from '.././config.service';
 
 @Pipe({
   name: 'countdowncolor'
 })
 export class CountdownColorPipe implements PipeTransform {
+  startSecondsAtMinute: number = 5; // default to 5 minutes
+
+  constructor(
+    private config?: ConfigService
+  ) {
+    if ((config?.settings.countdownStartSecondsAtMinute ?? 0) > 0) // lowest allowed setting is 1 min
+      this.startSecondsAtMinute = config?.settings.countdownStartSecondsAtMinute!;
+  }
 
   transform(value: number, ...args: unknown[]): string {
     if (value >= (1000 * 60 * 60)) { // >= 1 hour
       return "countdown-green";
-    } else if (value >= (1000 * 60 * 5)) { // < 1 hour and >= 5 min
+    } else if (value >= (1000 * 60 * this.startSecondsAtMinute)) { // < 1 hour and >= <threshold> min
       return "countdown-yellow";
-    } else if (value != 0) {  // < 5 min and not 0 (game over)
+    } else if (value != 0) {  // < <threshold> min and not 0 (game over)
       return "countdown-red";
     }
     return "";

--- a/projects/gameboard-ui/src/app/utility/pipes/countdown.pipe.ts
+++ b/projects/gameboard-ui/src/app/utility/pipes/countdown.pipe.ts
@@ -2,11 +2,20 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 import { Pipe, PipeTransform } from '@angular/core';
+import { ConfigService } from '.././config.service';
 
 @Pipe({
   name: 'countdown'
 })
 export class CountdownPipe implements PipeTransform {
+  startSecondsAtMinute: number = 5; // default to 5 minutes
+
+  constructor(
+    private config?: ConfigService
+  ) {
+    if ((config?.settings.countdownStartSecondsAtMinute ?? 0) > 0) // lowest allowed setting is 1 min
+      this.startSecondsAtMinute = config?.settings.countdownStartSecondsAtMinute!;
+  }
 
   transform(value: number, ...args: unknown[]): string {
     const days = Math.floor(value / 1000 / 60 / 60 / 24);
@@ -23,7 +32,7 @@ export class CountdownPipe implements PipeTransform {
     if (!days && (!!hours || !!minutes)) { // days < 1 and total minutes > 0
       r.push(minutes + "m");
     } 
-    if (!days && !hours && (minutes < 5) && (!!minutes || !!seconds)) { // total hours < 1, minutes < 5, total seconds > 0
+    if (!days && !hours && (minutes < this.startSecondsAtMinute) && (!!minutes || !!seconds)) { // total hours < 1, minutes < 5, total seconds > 0
       r.push(seconds + "s");
     }
     return r.join(" ");

--- a/projects/gameboard-ui/src/app/utility/pipes/countdown.pipe.ts
+++ b/projects/gameboard-ui/src/app/utility/pipes/countdown.pipe.ts
@@ -8,24 +8,25 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class CountdownPipe implements PipeTransform {
 
-  transform(value: number, ...args: unknown[]): unknown {
-    const tag = [ 's', 'm', 'h', 'd' ];
-    const a: number[] = [
-      value / 1000,
-      value / 1000 / 60,
-      value / 1000 / 60 / 60,
-      value / 1000 / 60 / 60 / 24
-    ];
-
-    let r = '';
-
-    for (let i = 0; i < a.length; i++) {
-      value = Math.floor(a[i]);
-      if (!!value) {
-        r = value + tag[i];
-      }
+  transform(value: number, ...args: unknown[]): string {
+    const days = Math.floor(value / 1000 / 60 / 60 / 24);
+    const hours = Math.floor(value / 1000 / 60 / 60 % 24);
+    const minutes =  Math.floor(value / 1000 / 60 % 60);
+    const seconds = Math.floor(value / 1000 % 60);
+    let r: string[] = [];
+    if (!!days) { // total days > 0
+      r.push(days + "d");
     }
-    return r;
+    if (!!days || !!hours) { // total hours > 0
+      r.push(hours + "h");
+    }
+    if (!days && (!!hours || !!minutes)) { // days < 1 and total minutes > 0
+      r.push(minutes + "m");
+    } 
+    if (!days && !hours && (minutes < 5) && (!!minutes || !!seconds)) { // total hours < 1, minutes < 5, total seconds > 0
+      r.push(seconds + "s");
+    }
+    return r.join(" ");
   }
 
 }

--- a/projects/gameboard-ui/src/app/utility/utility.module.ts
+++ b/projects/gameboard-ui/src/app/utility/utility.module.ts
@@ -13,6 +13,7 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { AgedDatePipe } from './pipes/aged-date.pipe';
 import { CamelspacePipe } from './pipes/camelspace.pipe';
 import { CountdownPipe } from './pipes/countdown.pipe';
+import { CountdownColorPipe } from './pipes/countdown-color.pipe';
 import { ShortDatePipe } from './pipes/short-date.pipe';
 import { ShortTimePipe } from './pipes/short-time.pipe';
 import { UntagPipe } from './pipes/untag.pipe';
@@ -40,6 +41,7 @@ const components = [
   AgedDatePipe,
   CamelspacePipe,
   CountdownPipe,
+  CountdownColorPipe,
   ShortDatePipe,
   ShortTimePipe,
   UntagPipe,

--- a/projects/gameboard-ui/src/environments/environment.ts
+++ b/projects/gameboard-ui/src/environments/environment.ts
@@ -11,6 +11,7 @@ export const environment = {
     imghost: 'http://localhost:5002/img',
     tochost: 'http://localhost:5002/doc',
     tocfile: 'toc.json',
+    countdownStartSecondsAtMinute: 5,
     oidc: {
       client_id: 'dev-code',
       // authority: 'http://localhost:5000',


### PR DESCRIPTION
UI-only change.

- Change to `countdown` pipe to improve formatting for time remaining output
- New `countdowncolor` pipe to change element class for time remaining based on thresholds
- Green, yellow, red text color styles applied based on time remaining 
- New env var `countdownStartSecondsAtMinute` to specify when seconds should start displaying. This also determines when the countdown style turns red.

This enhances the basic countdown pipe by showing more than just one unit at a time. For example, instead of just "1h" it could say "1h 43m". The text color will also change to indicate how close a session is to ending.  
