### PR TITLE
New certifcate panel on game, new profile list, and admin settings

### DIFF
--- a/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.html
+++ b/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.html
@@ -145,6 +145,36 @@
           </div>
         </div>
       </div>
+
+      <div class="col-12">
+        <div class="form-group pb-0 pt-1">
+          <label for="certificateTemplate-input">Certificate Template</label>
+          <textarea rows="11" type="text" class="form-control" id="certificateTemplate-input"
+            name="certificateTemplate" [(ngModel)]="game.certificateTemplate"></textarea>
+          <small>design with HTML and inline/internal CSS; use a 11:8.5 aspect ratio</small>
+          <button class="btn btn-sm btn-link-white" [(ngModel)]="showCertificateInfo" [ngModelOptions]="{standalone: true}" btnCheckbox>
+            <fa-icon [icon]="faInfoCircle"></fa-icon>
+          </button>
+          <div class="ml-4 px-2"*ngIf="showCertificateInfo">
+            <p class="cert-info mb-2">
+    Insert dynamic content by referring to a property with double-curly syntax <code>{{"\{\{game_name\}\}"}}</code>. For example, <code>&lt;h1&gt;{{"\{\{leaderboard_name\}\}"}}&lt;/h1&gt;</code>. <br>
+    The following properties will get replaced when a player certificate renders:
+            </p>
+            <pre>
+      game_name &mdash; Name of this game 
+      competition &mdash; Competition type of this game
+      season &mdash; Season of this game
+      round &mdash; Round of this game
+      track &mdash; Track of this game
+      user_name &mdash; Individual user's approved name
+      score &mdash; Total player score for this game
+      rank &mdash; Final leaderboard ranking of the player
+      leaderboard_name &mdash; Approved name for either team or individual
+      date &mdash; Date player's session ended for this game</pre>
+          </div>
+        </div>
+      </div>
+
     </div>
 
     <div class="section-header" tabindex="0" (click)="show(2)">

--- a/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.html
+++ b/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.html
@@ -160,7 +160,7 @@
     Insert dynamic content by referring to a property with double-curly syntax <code>{{"\{\{game_name\}\}"}}</code>. For example, <code>&lt;h1&gt;{{"\{\{leaderboard_name\}\}"}}&lt;/h1&gt;</code>. <br>
     The following properties will get replaced when a player certificate renders:
             </p>
-            <pre>
+            <pre class="mb-1">
       game_name &mdash; Name of this game 
       competition &mdash; Competition type of this game
       season &mdash; Season of this game
@@ -171,6 +171,10 @@
       rank &mdash; Final leaderboard ranking of the player
       leaderboard_name &mdash; Approved name for either team or individual
       date &mdash; Date player's session ended for this game</pre>
+            <p class="cert-info mb-2">
+      Tip: Create an outer div with fixed height and width and <code>position: relative</code>. Create inner divs with <code>position: absolute; text-align: center;</code> and set textbox width and X/Y position with <code>top: __px; left: __px; width: __px;</code>.
+      To add a background image, use <code>background-size: 100% 100%; background-image: url('URL_HERE');</code>
+            </p>
           </div>
         </div>
       </div>

--- a/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.scss
+++ b/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.scss
@@ -15,3 +15,6 @@ label {
 .section {
   margin-bottom: 2rem;
 }
+.cert-info {
+  font-size: 87.5%;
+}

--- a/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.ts
+++ b/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.ts
@@ -3,7 +3,7 @@
 
 import { AfterViewInit, Component, Input, OnInit, ViewChild } from '@angular/core';
 import { FormGroup, NgForm } from '@angular/forms';
-import { faArrowLeft, faCaretDown, faCaretRight, faCloudUploadAlt, faCopy, faGamepad, faToggleOff, faToggleOn, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faArrowLeft, faCaretDown, faCaretRight, faCloudUploadAlt, faCopy, faGamepad, faToggleOff, faToggleOn, faTrash, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { Observable } from 'rxjs';
 import { debounceTime, filter, map, switchMap, tap } from 'rxjs/operators';
 import { Game } from '../../api/game-models';
@@ -28,6 +28,7 @@ export class GameEditorComponent implements OnInit, AfterViewInit {
   feedbackMessage?: string = undefined;
   feedbackWarning: boolean = false;
   viewing = 1;
+  showCertificateInfo = false;
 
   faCaretDown = faCaretDown;
   faCaretRight = faCaretRight;
@@ -38,6 +39,7 @@ export class GameEditorComponent implements OnInit, AfterViewInit {
   faSave = faCloudUploadAlt;
   faGo = faGamepad;
   faArrowLeft = faArrowLeft;
+  faInfoCircle = faInfoCircle;
 
   constructor(
     private route: ActivatedRoute,

--- a/projects/gameboard-ui/src/app/api/game-models.ts
+++ b/projects/gameboard-ui/src/app/api/game-models.ts
@@ -20,6 +20,7 @@ export interface GameDetail {
   gameEnd: Date;
   gameMarkdown: string;
   feedbackConfig: string;
+  certificateTemplate: string;
   feedbackTemplate: FeedbackTemplate;
   registrationMarkdown: string;
   registrationOpen: Date;
@@ -45,6 +46,8 @@ export interface GameDetail {
   cardText1: string;
   cardText2: string;
   cardText3: string;
+  isLive: boolean;
+  hasEnded: boolean;
 }
 
 export interface Game extends GameDetail

--- a/projects/gameboard-ui/src/app/api/player-models.ts
+++ b/projects/gameboard-ui/src/app/api/player-models.ts
@@ -1,7 +1,9 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
+import { SafeHtml } from "@angular/platform-browser";
 import { ChallengeResult } from "./board-models";
+import { Game } from "./game-models";
 import { Search } from "./models";
 
 export interface Player {
@@ -221,6 +223,12 @@ export interface ObserveTeamMember {
   role: PlayerRole;
   minimized: boolean;
   fullWidth: boolean;
+}
+
+export interface PlayerCertificate {
+  game: Game;
+  player: Player;
+  html: string;
 }
 
 export interface PlayerSearch extends Search {

--- a/projects/gameboard-ui/src/app/api/player.service.ts
+++ b/projects/gameboard-ui/src/app/api/player.service.ts
@@ -6,7 +6,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { ConfigService } from '../utility/config.service';
-import { ChangedPlayer, NewPlayer, Player, PlayerEnlistment, SessionChangeRequest, Standing, Team, TeamAdvancement, TeamInvitation, TeamSummary, TimeWindow } from './player-models';
+import { ChangedPlayer, NewPlayer, Player, PlayerCertificate, PlayerEnlistment, SessionChangeRequest, Standing, Team, TeamAdvancement, TeamInvitation, TeamSummary, TimeWindow } from './player-models';
 
 @Injectable({
   providedIn: 'root'
@@ -85,6 +85,12 @@ export class PlayerService {
   }
   public observeTeams(id: string): Observable<any> {
     return this.http.get<Team>(`${this.url}/teams/observe/${id}`);
+  }
+  public getCertificate(id: string): Observable<PlayerCertificate> {
+    return this.http.get<PlayerCertificate>(`${this.url}/certificate/${id}`);
+  }
+  public getUserCertificates(): Observable<PlayerCertificate[]> {
+    return this.http.get<PlayerCertificate[]>(`${this.url}/certificates`);
   }
 
   public transform(p: Player): Player {

--- a/projects/gameboard-ui/src/app/game/certificate/certificate.component.html
+++ b/projects/gameboard-ui/src/app/game/certificate/certificate.component.html
@@ -1,0 +1,13 @@
+<ng-container *ngIf="cert$ | async as cert">
+  <div class="m-2">
+    <div class="container mb-3">
+      <button class="btn btn-info float-right" (click)="print()"><fa-icon [icon]="faPrint"></fa-icon> Print</button>
+    </div>
+  </div>
+  <div class="container-fluid">
+    <div class="mx-3">
+      <iframe [srcdoc]="cert" [frameBorder]="0">
+      </iframe>
+    </div>
+  </div>
+</ng-container>

--- a/projects/gameboard-ui/src/app/game/certificate/certificate.component.scss
+++ b/projects/gameboard-ui/src/app/game/certificate/certificate.component.scss
@@ -1,0 +1,5 @@
+iframe {
+  width: 100%;
+  height: 1000px;
+  resize: both;
+}

--- a/projects/gameboard-ui/src/app/game/certificate/certificate.component.spec.ts
+++ b/projects/gameboard-ui/src/app/game/certificate/certificate.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CertificateComponent } from './certificate.component';
+
+describe('CertificateComponent', () => {
+  let component: CertificateComponent;
+  let fixture: ComponentFixture<CertificateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CertificateComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CertificateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/gameboard-ui/src/app/game/certificate/certificate.component.ts
+++ b/projects/gameboard-ui/src/app/game/certificate/certificate.component.ts
@@ -1,0 +1,45 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { faPrint } from '@fortawesome/free-solid-svg-icons';
+import { Observable } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
+import { GameContext } from '../../api/models';
+import { PlayerService } from '../../api/player.service';
+
+@Component({
+  selector: 'app-certificate',
+  templateUrl: './certificate.component.html',
+  styleUrls: ['./certificate.component.scss']
+})
+export class CertificateComponent implements OnInit {
+  @Input() ctx!: GameContext;
+  cert$!: Observable<SafeHtml>;
+  toPrint: string = "";
+  faPrint = faPrint;
+
+  constructor(
+    private apiPlayer: PlayerService,
+    private sanitizer: DomSanitizer
+  ) { }
+
+  ngOnInit(): void {
+    this.cert$ = this.apiPlayer.getCertificate(this.ctx.player.id).pipe(
+      tap(g => this.toPrint = g.html),
+      // sanitize html to render in iframe binding and add wrapper div to center certificate
+      map(g => this.sanitizer.bypassSecurityTrustHtml(`<div style="max-width: max-content; margin: auto;">${g.html}</div>`)),
+    );
+  }
+
+  print(): void {
+    let printWindow = window.open('', '', '');
+    // make sure background is always there and no margins to print to pdf as is
+    printWindow?.document?.write(`<style type="text/css">* {-webkit-print-color-adjust: exact !important; color-adjust: exact !important; }</style>`)
+    printWindow?.document?.write(`<style type="text/css">@media print { body { margin: 0mm!important;} @page{ margin: 0mm!important; }}</style>`);
+    printWindow?.document?.write(`<style type="text/css" media="print"> @page { size: landscape; } </style>`);
+    printWindow?.document.write(this.toPrint);
+    printWindow?.document.close();
+    printWindow?.focus();
+    printWindow?.addEventListener('load', printWindow?.print, true); // wait until all content loads before printing
+    // don't close new tab automatically in case want to keep open for some reason [ printWindow?.close(); ]
+  }
+}

--- a/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.html
+++ b/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.html
@@ -1,5 +1,5 @@
-<div class="section-header" tabindex="0" (click)="toggle()">
-  <fa-icon [icon]="show ? faCaretDown : faCaretRight" size="lg"></fa-icon>
+<div class="d-flex align-items-center" tabindex="0" (click)="toggle()">
+  <fa-icon class="d-inline" [icon]="show ? faCaretDown : faCaretRight" size="lg"></fa-icon>
   <span>
     <h3 *ngIf="type == 'challenge'" class="d-inline">{{title}}</h3>
     <h2 *ngIf="type == 'game'" class="d-inline">{{title}}</h2>

--- a/projects/gameboard-ui/src/app/game/game-page/game-page.component.html
+++ b/projects/gameboard-ui/src/app/game/game-page/game-page.component.html
@@ -27,6 +27,25 @@
       <markdown [data]="ctx.game.gameMarkdown"></markdown>
     </div>
 
+     <!-- if auth'd, enrolled, game ended, and certificate defined -->
+    <ng-container *ngIf="!!ctx.user.id && !!ctx.player.id && ctx.game.hasEnded && !!ctx.game.certificateTemplate">
+      <div class="row justify-content-center">
+        <div class="col panel">
+          <div tabindex="0" (click)="showCert = !showCert">
+            <div class="d-flex align-items-center">
+              <fa-icon class="d-inline" [icon]="showCert ? faCaretDown : faCaretRight" size="lg"></fa-icon>
+              <span>
+                <h2 class="d-inline">Certificate</h2>
+              </span>
+            </div>
+          </div>
+          <div [hidden]="!showCert">
+              <app-certificate [ctx]="ctx"></app-certificate>
+          </div>
+        </div>
+      </div>
+    </ng-container>
+
     <div class="row justify-content-center">
       <!-- if auth'd -->
       <ng-container *ngIf="!!ctx.user.id">

--- a/projects/gameboard-ui/src/app/game/game-page/game-page.component.ts
+++ b/projects/gameboard-ui/src/app/game/game-page/game-page.component.ts
@@ -3,12 +3,12 @@
 
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { faExternalLinkAlt, faExternalLinkSquareAlt, faListOl } from '@fortawesome/free-solid-svg-icons';
-import { asyncScheduler, combineLatest, Observable, of, scheduled, timer } from 'rxjs';
+import { faCaretDown, faCaretRight, faExternalLinkAlt, faListOl } from '@fortawesome/free-solid-svg-icons';
+import { asyncScheduler, combineLatest, Observable, scheduled } from 'rxjs';
 import { filter, map, switchMap, tap, zipAll } from 'rxjs/operators';
 import { Game } from '../../api/game-models';
 import { GameService } from '../../api/game.service';
-import { Player, Standing } from '../../api/player-models';
+import { Player } from '../../api/player-models';
 import { PlayerService } from '../../api/player.service';
 import { ApiUser } from '../../api/user-models';
 import { UserService as LocalUserService } from '../../utility/user.service';
@@ -20,9 +20,11 @@ import { UserService as LocalUserService } from '../../utility/user.service';
 })
 export class GamePageComponent implements OnInit {
   ctx$: Observable<{ user: ApiUser; game: Game; player: Player; }>;
+  showCert = false;
   faLink = faExternalLinkAlt;
   faList = faListOl;
-
+  faCaretDown = faCaretDown; 
+  faCaretRight = faCaretRight;
   constructor(
     router: Router,
     route: ActivatedRoute,

--- a/projects/gameboard-ui/src/app/game/game.module.ts
+++ b/projects/gameboard-ui/src/app/game/game.module.ts
@@ -23,6 +23,7 @@ import { ScoreboardPageComponent } from './scoreboard-page/scoreboard-page.compo
 import { ScoreboardTableComponent } from './scoreboard-table/scoreboard-table.component';
 import { PlayerPresenceComponent } from './player-presence/player-presence.component';
 import { FeedbackFormComponent } from './feedback-form/feedback-form.component';
+import { CertificateComponent } from './certificate/certificate.component';
 
 
 @NgModule({
@@ -38,7 +39,8 @@ import { FeedbackFormComponent } from './feedback-form/feedback-form.component';
     ScoreboardPageComponent,
     ScoreboardTableComponent,
     PlayerPresenceComponent,
-    FeedbackFormComponent
+    FeedbackFormComponent,
+    CertificateComponent
   ],
   exports: [
   ],

--- a/projects/gameboard-ui/src/app/home/certificate-list/certificate-list.component.html
+++ b/projects/gameboard-ui/src/app/home/certificate-list/certificate-list.component.html
@@ -14,7 +14,7 @@
   <div *ngFor="let cert of certs" class="row rounded bg-secondary mb-1 mx-0 py-2">
     <div class="col-3 d-flex flex-wrap">
       <div class="ml-2">
-        <a class="btn btn-link p-0" [routerLink]="['/', 'game', cert.game.id]"><span class="mr-2 h5">{{cert.game.name}}</span></a>
+        <a class="btn btn-link p-0 text-left" [routerLink]="['/', 'game', cert.game.id]"><span class="mr-2 h5">{{cert.game.name}}</span></a>
         <div class="text-muted">
           <span> {{cert.game.gameEnd | shortdate}}</span>
         </div>

--- a/projects/gameboard-ui/src/app/home/certificate-list/certificate-list.component.html
+++ b/projects/gameboard-ui/src/app/home/certificate-list/certificate-list.component.html
@@ -1,0 +1,45 @@
+<a class="btn btn-link" routerLink="../">
+  <fa-icon [icon]="faArrowLeft"></fa-icon>
+  <span>Back</span>
+</a>
+
+<h2>Certificates</h2>
+<div class="row mx-0 mb-1">
+  <div class="col-3">Game</div>
+  <div class="col-2">Rank</div>
+  <div class="col-4">Leaderboard Name</div>
+  <div class="col-2 text-right ml-auto">Certificate</div>
+</div>
+<ng-container *ngIf="certs$ | async as certs; else loading">
+  <div *ngFor="let cert of certs" class="row rounded bg-secondary mb-1 mx-0 py-2">
+    <div class="col-3 d-flex flex-wrap">
+      <div class="ml-2">
+        <a class="btn btn-link p-0" [routerLink]="['/', 'game', cert.game.id]"><span class="mr-2 h5">{{cert.game.name}}</span></a>
+        <div class="text-muted">
+          <span> {{cert.game.gameEnd | shortdate}}</span>
+        </div>
+      </div>
+    </div>
+    <div class="col-2 align-self-center">
+      <span class="mr-4">{{cert.player.rank}} <fa-icon [icon]="faMedal"></fa-icon></span>
+    </div>
+    <div class="col-4 align-self-center">
+      <span class=""><fa-icon [icon]="cert.game.allowTeam ? faUsers : faUser"></fa-icon> {{cert.player.approvedName}}</span>
+    </div>
+    <div class="col-2 align-self-center text-right ml-auto">
+      <button *ngIf="true" class="btn btn-outline-success btn-sm ml-1" (click)="print(cert.html)">
+        <fa-icon [icon]="faPrint"></fa-icon>
+        <span>Print</span>
+      </button>
+    </div>
+  </div> 
+  <div *ngIf="!certs?.length" class="text-center text-muted my-4">
+    No certificates yet
+  </div>
+</ng-container>
+
+<ng-template #loading>
+  <div class="text-center">
+    <app-spinner></app-spinner>
+  </div>
+</ng-template>

--- a/projects/gameboard-ui/src/app/home/certificate-list/certificate-list.component.scss
+++ b/projects/gameboard-ui/src/app/home/certificate-list/certificate-list.component.scss
@@ -1,0 +1,3 @@
+.preview {
+    max-height: 400px;;
+}

--- a/projects/gameboard-ui/src/app/home/certificate-list/certificate-list.component.spec.ts
+++ b/projects/gameboard-ui/src/app/home/certificate-list/certificate-list.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CertificateListComponent } from './certificate-list.component';
+
+describe('CertificateListComponent', () => {
+  let component: CertificateListComponent;
+  let fixture: ComponentFixture<CertificateListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CertificateListComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CertificateListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/gameboard-ui/src/app/home/certificate-list/certificate-list.component.ts
+++ b/projects/gameboard-ui/src/app/home/certificate-list/certificate-list.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+import { faArrowLeft, faAward, faPrint, faMedal, faUser, faUsers } from '@fortawesome/free-solid-svg-icons';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { PlayerCertificate } from '../../api/player-models';
+import { PlayerService } from '../../api/player.service';
+
+@Component({
+  selector: 'app-certificate-list',
+  templateUrl: './certificate-list.component.html',
+  styleUrls: ['./certificate-list.component.scss']
+})
+export class CertificateListComponent implements OnInit {
+  faArrowLeft = faArrowLeft;
+  faAward = faAward;
+  faMedal = faMedal;
+  faPrint = faPrint;
+  faUser = faUser
+  faUsers = faUsers
+  certs$: Observable<PlayerCertificate[]>;
+  constructor(
+    private apiPlayer: PlayerService,
+    private sanitizer: DomSanitizer
+    ) { 
+      this.certs$ = apiPlayer.getUserCertificates().pipe(
+        map(c => c.map(a => ({...a, safeHtml: sanitizer.bypassSecurityTrustHtml(a.html)}))
+      ));
+  }
+
+  ngOnInit(): void {
+  }
+
+  print(html: string): void {
+    let printWindow = window.open('', '', '');
+    // make sure background is always there and no margins to print to pdf as is
+    printWindow?.document?.write(`<style type="text/css">* {-webkit-print-color-adjust: exact !important; color-adjust: exact !important; }</style>`)
+    printWindow?.document?.write(`<style type="text/css">@media print { body { margin: 0mm!important;} @page{ margin: 0mm!important; }}</style>`);
+    printWindow?.document?.write(`<style type="text/css" media="print"> @page { size: landscape; } </style>`);
+    printWindow?.document.write(html);
+    printWindow?.document.close();
+    printWindow?.focus();
+    printWindow?.addEventListener('load', printWindow?.print, true); // wait until all content loads before printing
+    // don't close new tab automatically in case want to keep open for some reason [ printWindow?.close(); ]
+   }
+
+}

--- a/projects/gameboard-ui/src/app/home/home.module.ts
+++ b/projects/gameboard-ui/src/app/home/home.module.ts
@@ -17,6 +17,7 @@ import { MarkdownModule } from 'ngx-markdown';
 import { FormsModule } from '@angular/forms';
 import { AuthGuard } from '../utility/auth.guard';
 import { TocPageComponent } from './toc-page/toc-page.component';
+import { CertificateListComponent } from './certificate-list/certificate-list.component';
 
 
 
@@ -30,6 +31,7 @@ import { TocPageComponent } from './toc-page/toc-page.component';
     ForbiddenComponent,
     LoginPageComponent,
     TocPageComponent,
+    CertificateListComponent,
   ],
   imports: [
     CommonModule,
@@ -39,6 +41,7 @@ import { TocPageComponent } from './toc-page/toc-page.component';
         { path: 'login', component: LoginPageComponent },
         { path: 'oidc', component: OidcComponent },
         { path: 'profile', component: ProfileComponent, canActivate: [AuthGuard] },
+        { path: 'profile/certificates', component: CertificateListComponent, canActivate: [AuthGuard] },
         { path: 'doc/:id', component: TocPageComponent },
         { path: 'forbidden', component: ForbiddenComponent },
         { path: 'home', component: LandingComponent }

--- a/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.html
+++ b/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.html
@@ -2,6 +2,10 @@
 <!-- Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information. -->
 
 <ng-container *ngIf="ctx$ | async as ctx">
+    
+    <div class="d-flex justify-content-end">
+        <a class="btn btn-link" [routerLink]="['/', 'profile', 'certificates']">Certificates</a>
+    </div>
 
     <h4>Set your display name</h4>
 

--- a/projects/gameboard-ui/src/app/utility/utility.module.ts
+++ b/projects/gameboard-ui/src/app/utility/utility.module.ts
@@ -29,6 +29,7 @@ import { MessageBoardComponent } from './components/message-board/message-board.
 import { SafeUrlPipe } from './pipes/safe-url.pipe';
 import { ObserveOrderPipe } from './pipes/observe-order.pipe';
 import { MatchesTermPipe } from './pipes/matches-term.pipe';
+import { RouterModule } from '@angular/router';
 
 const components = [
   ClipspanComponent,
@@ -62,7 +63,8 @@ const components = [
     FontAwesomeModule,
     AlertModule,
     TooltipModule.forRoot(),
-    ButtonsModule
+    ButtonsModule,
+    RouterModule
   ],
 })
 export class UtilityModule { }


### PR DESCRIPTION
Corresponding API changes: https://github.com/cmu-sei/Gameboard/pull/35

- New expandable panel to view and print certificate on game info page; only appears if the game has completed, a template is defined, and the player was enrolled 
- New page `/profile/certificates` to list all completed games with certificates that the user competed in
- New text area in admin settings for HTML template along with toggle to view info and available dynamic properties available
- Note: Only supply HTML content that would go inside`<body>...</body>` in the document. This can include adding styles as inline or internal CSS (e.g. `<style>div {color:red;}</style>`).
- The print button opens a new window populated with the generated HTML. It modifies it slightly to support better printing to PDF.

This allows an admin to copy in an HTML template for a game in the settings. Players can view a list of past certificates from their profile page or can view it on the main game page after a game completes. There is also a shortcut to print _only_ the certificate content in a new window. 