### PR TITLE
Improve game organization and management 

### DIFF
--- a/projects/gameboard-ui/src/app/admin/admin-page/admin-page.component.html
+++ b/projects/gameboard-ui/src/app/admin/admin-page/admin-page.component.html
@@ -2,7 +2,7 @@
 <!-- Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information. -->
 
 <div class="mb-4">
-  <h1 class="mb-0">Administration</h1>
+  <h1 class="admin-header mb-0">Administration</h1>
 </div>
 
 <main class="container mb-4 pb-4">

--- a/projects/gameboard-ui/src/app/admin/admin-page/admin-page.component.scss
+++ b/projects/gameboard-ui/src/app/admin/admin-page/admin-page.component.scss
@@ -1,3 +1,7 @@
 a {
   font-size: 1.3rem;
 }
+.admin-header {
+  padding-top: 1rem;
+  padding-left: 2rem;
+}

--- a/projects/gameboard-ui/src/app/admin/admin.module.ts
+++ b/projects/gameboard-ui/src/app/admin/admin.module.ts
@@ -10,6 +10,7 @@ import { GameDesignerComponent } from './game-designer/game-designer.component';
 import { UserRegistrarComponent } from './user-registrar/user-registrar.component';
 import { UtilityModule } from '../utility/utility.module';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ApiModule } from '../api/api.module';
@@ -79,6 +80,7 @@ import { FeedbackReportComponent } from './feedback-report/feedback-report.compo
     ApiModule,
     UtilityModule,
     FontAwesomeModule,
+    TooltipModule,
     ButtonsModule,
     BsDropdownModule
   ]

--- a/projects/gameboard-ui/src/app/admin/admin.module.ts
+++ b/projects/gameboard-ui/src/app/admin/admin.module.ts
@@ -11,6 +11,7 @@ import { UserRegistrarComponent } from './user-registrar/user-registrar.componen
 import { UtilityModule } from '../utility/utility.module';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
+import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ApiModule } from '../api/api.module';
 import { FormsModule } from '@angular/forms';
 import { GameEditorComponent } from './game-editor/game-editor.component';
@@ -78,7 +79,8 @@ import { FeedbackReportComponent } from './feedback-report/feedback-report.compo
     ApiModule,
     UtilityModule,
     FontAwesomeModule,
-    ButtonsModule
+    ButtonsModule,
+    BsDropdownModule
   ]
 })
 export class AdminModule { }

--- a/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
+++ b/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
@@ -133,12 +133,20 @@
                 <tr *ngFor="let game of games; trackBy:trackById">
                   <td class="thin-col sticky-card sticky-cell"><img [src]="game.cardUrl" class="table-card"></td>
                   <td class="thin-col">
-                    <fa-icon [icon]="game.isPublished ? faGlobe : faEyeSlash" [class.text-success1]="game.isPublished"></fa-icon>
-                    <fa-icon [icon]="game.allowReset ? faUndo : faLock"></fa-icon>
+                    <div [tooltip]="game.isPublished ? 'Published' : 'Unpublished'" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">
+                      <fa-icon [icon]="game.isPublished ? faGlobe : faEyeSlash"></fa-icon>
+                    </div>
+                    <div [tooltip]="game.allowReset ? 'Reset Allowed' : 'Reset Not Allowed'" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">
+                      <fa-icon [icon]="game.allowReset ? faUndo : faLock"></fa-icon>
+                    </div>
                   </td>
                   <td class="thin-col">
-                    <fa-icon [icon]="game.allowTeam ? faTeam : faUser"></fa-icon>
-                    <fa-icon [icon]="!!game.feedbackTemplate?.challenge?.length || !!game.feedbackTemplate?.game?.length ? faChartBar : faCommentSlash"></fa-icon>
+                    <div [tooltip]="game.allowTeam ? 'Team' : 'Individual'" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">
+                      <fa-icon [icon]="game.allowTeam ? faTeam : faUser"></fa-icon>
+                    </div>
+                    <div [tooltip]="!!game.feedbackTemplate?.challenge?.length || !!game.feedbackTemplate?.game?.length ? 'Accepts Feedback' : 'No Feedback'" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">
+                      <fa-icon [icon]="!!game.feedbackTemplate?.challenge?.length || !!game.feedbackTemplate?.game?.length ? faChartBar : faCommentSlash"></fa-icon>
+                    </div>
                   </td>
                   <td class="thin-col sticky-options sticky-cell">
                     <div dropdown class="btn-group" container="body" #dropdown="bs-dropdown" [autoClose]="true" [insideClick]="true">

--- a/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
+++ b/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
@@ -48,7 +48,7 @@
       </div>
     </div>
 
-    <ng-container *ngIf="games$ | async as games">
+    <ng-container *ngIf="games$ | async as games; else loading">
 
       <!-- Card view mode -->
       <ng-container *ngIf="!tableView">
@@ -210,3 +210,9 @@
     <app-announce></app-announce>
   </div>
 </div>
+
+<ng-template #loading>
+  <div class="text-center w-100">
+    <app-spinner></app-spinner>
+  </div>
+</ng-template>

--- a/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
+++ b/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
@@ -52,9 +52,9 @@
 
       <!-- Card view mode -->
       <ng-container *ngIf="!tableView">
-        <div class="dropzone col-3">
-          <app-dropzone class="" (dropped)="dropped($event)">
-            <pre>Drag in a yaml game array or</pre>
+        <div class="dropzone col-3 card bg-transparent">
+          <app-dropzone class="h-100 my-3" (dropped)="dropped($event)">
+            <pre class="overflow-hidden">Drag in a yaml game array or</pre>
             <button class="btn btn-secondary btn-sm" (click)="create()">
               <fa-icon [icon]="faPlus"></fa-icon>
               <span>New Game</span>
@@ -62,10 +62,10 @@
           </app-dropzone>
         </div>
 
-        <div class="wrapper col-3" *ngFor="let g of games; trackBy:trackById" (mouseenter)="on(g)"
+        <div class="wrapper col-3 my-3" *ngFor="let g of games; trackBy:trackById" (mouseenter)="on(g)"
           (mouseleave)="off(g)" (focus)="on(g)" tabindex="0">
 
-          <app-game-card [game]="g" class="col-lg-3 col-md-4 col-6 mb-4"></app-game-card>
+          <app-game-card [game]="g"></app-game-card>
 
           <div class="overlay d-flex flex-column justify-content-center align-items-center" *ngIf="hot===g">
             <a class="btn btn-outline-info my-2" [routerLink]="['../registrar', g.id]">

--- a/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
+++ b/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
@@ -150,6 +150,7 @@
                       <div *dropdownMenu class="dropdown-menu">
                         <a class="dropdown-item px-3" [routerLink]="['../registrar', game.id]"><fa-icon class="mr-1" [icon]="faUsers"></fa-icon>Players</a>
                         <a class="dropdown-item px-3" [routerLink]="['../observer/challenges', game.id]"><fa-icon class="mr-1" [icon]="faTv"></fa-icon>Observe</a>
+                        <a class="dropdown-item px-3" [routerLink]="['/game', game.id]"><fa-icon class="mr-1" [icon]="faGamepad"></fa-icon>Lobby</a>
                         <a class="dropdown-item px-3" [routerLink]="['../designer', game.id]"><fa-icon class="mr-1" [icon]="faCog"></fa-icon>Settings</a>
                         <div class="dropdown-divider"></div>
                         <a class="dropdown-item px-3" (click)="clone(game)"><fa-icon class="mr-1" [icon]="faClone"></fa-icon>Clone</a>

--- a/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
+++ b/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
@@ -20,8 +20,8 @@
     <div class="input-group-prepend">
       <span id="search-label" class="input-group-text">Search</span>
     </div>
-    <input id="search-input" type="search" class="form-control" [(ngModel)]="search.term" (input)="typing($event)"
-      aria-label="search term" aria-describedby="search-label">
+    <input id="search-input" type="search" autocomplete="off" class="form-control border-0" [(ngModel)]="search.term" (input)="typing($event)"
+      aria-label="search term" aria-describedby="search-label" placeholder="Enter name, season, track, division, series, sponsor, key, mode, or id">
   </div>
 
   <!-- <div class=""> -->

--- a/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
+++ b/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
@@ -16,7 +16,7 @@
 <!-- game browser -->
 <div class="row">
 
-  <div class="input-group mb-4 col-12">
+  <div class="input-group mb-2 col-12">
     <div class="input-group-prepend">
       <span id="search-label" class="input-group-text">Search</span>
     </div>
@@ -26,54 +26,172 @@
 
   <!-- <div class=""> -->
 
-    <div class="dropzone col-3">
-      <app-dropzone class="" (dropped)="dropped($event)">
-        <pre>Drag in a yaml game array or</pre>
-        <button class="btn btn-secondary btn-sm" (click)="create()">
-          <fa-icon [icon]="faPlus"></fa-icon>
-          <span>New Game</span>
-        </button>
-      </app-dropzone>
+
+
+    <div *ngIf="tableView" class="col-4">
+      <button class="btn btn-secondary btn-sm" (click)="create()">
+        <fa-icon [icon]="faPlus"></fa-icon>
+        <span>New Game</span>
+      </button>
     </div>
-
-    <div class="wrapper col-3" *ngFor="let g of games$ | async; trackBy:trackById" (mouseenter)="on(g)"
-      (mouseleave)="off(g)" (focus)="on(g)" tabindex="0">
-
-      <app-game-card [game]="g" class="col-lg-3 col-md-4 col-6 mb-4"></app-game-card>
-
-      <div class="overlay d-flex flex-column justify-content-center align-items-center" *ngIf="hot===g">
-        <a class="btn btn-outline-info my-2" [routerLink]="['../registrar', g.id]">
-          <fa-icon [icon]="faUsers"></fa-icon>
-          <span>Players</span>
-        </a>
-        <a class="btn btn-outline-info my-2" [routerLink]="['../observer/challenges', g.id]">
-          <fa-icon [icon]="faTv"></fa-icon>
-          <span>Observe</span>
-        </a>
-        <a class="btn btn-outline-info my-2" [routerLink]="['../designer', g.id]">
-          <fa-icon [icon]="faCog"></fa-icon>
-          <span>Settings</span>
-        </a>
-        <div>
-          <button class="btn btn-outline-info btn-sm mx-1" (click)="clone(g)">
-            <fa-icon [icon]="faCopy"></fa-icon>
-            <span>Clone</span>
-          </button>
-          <button class="btn btn-outline-info btn-sm mx-1" (click)="yaml(g)">
-            <fa-icon [icon]="faCopy"></fa-icon>
-            <span>yaml</span>
-          </button>
-          <button class="btn btn-outline-info btn-sm mx-1" (click)="json(g)">
-            <fa-icon [icon]="faCopy"></fa-icon>
-            <span>json</span>
-          </button>
+    <div class="col-4 my-0 py-0" [class]="tableView ? 'offset-4' : 'offset-8'">
+      <div class="pb-0 pt-1 my-0 py-0">
+        <div class="text-white float-right auto-h d-flex align-items-center my-0 py-0">
+          <label class="py-0 my-0">Cards</label>
+          <label class="btn text-info my-0 py-0" btnCheckbox id="isPublished-input"
+                 name="isPublished" (click)="toggleViewMode()">
+            <fa-icon *ngIf="!tableView" [icon]="faToggleOff" size="lg"></fa-icon>
+            <fa-icon *ngIf="tableView" [icon]="faToggleOn" size="lg"></fa-icon>
+          </label>
+          <label class="py-0 my-0">Table</label>
         </div>
-        <app-confirm-button btnClass="btn btn-outline-danger my-2" (confirm)="delete(g)">
-          <fa-icon [icon]="faTrash"></fa-icon>
-          <span>Delete</span>
-        </app-confirm-button>
       </div>
     </div>
+
+    <ng-container *ngIf="games$ | async as games">
+
+      <!-- Card view mode -->
+      <ng-container *ngIf="!tableView">
+        <div class="dropzone col-3">
+          <app-dropzone class="" (dropped)="dropped($event)">
+            <pre>Drag in a yaml game array or</pre>
+            <button class="btn btn-secondary btn-sm" (click)="create()">
+              <fa-icon [icon]="faPlus"></fa-icon>
+              <span>New Game</span>
+            </button>
+          </app-dropzone>
+        </div>
+
+        <div class="wrapper col-3" *ngFor="let g of games; trackBy:trackById" (mouseenter)="on(g)"
+          (mouseleave)="off(g)" (focus)="on(g)" tabindex="0">
+
+          <app-game-card [game]="g" class="col-lg-3 col-md-4 col-6 mb-4"></app-game-card>
+
+          <div class="overlay d-flex flex-column justify-content-center align-items-center" *ngIf="hot===g">
+            <a class="btn btn-outline-info my-2" [routerLink]="['../registrar', g.id]">
+              <fa-icon [icon]="faUsers"></fa-icon>
+              <span>Players</span>
+            </a>
+            <a class="btn btn-outline-info my-2" [routerLink]="['../observer/challenges', g.id]">
+              <fa-icon [icon]="faTv"></fa-icon>
+              <span>Observe</span>
+            </a>
+            <a class="btn btn-outline-info my-2" [routerLink]="['../designer', g.id]">
+              <fa-icon [icon]="faCog"></fa-icon>
+              <span>Settings</span>
+            </a>
+            <div>
+              <button class="btn btn-outline-info btn-sm mx-1" (click)="clone(g)">
+                <fa-icon [icon]="faClone"></fa-icon>
+                <span>Clone</span>
+              </button>
+              <button class="btn btn-outline-info btn-sm mx-1" (click)="yaml(g)">
+                <fa-icon [icon]="faCopy"></fa-icon>
+                <span>yaml</span>
+              </button>
+              <button class="btn btn-outline-info btn-sm mx-1" (click)="json(g)">
+                <fa-icon [icon]="faCopy"></fa-icon>
+                <span>json</span>
+              </button>
+            </div>
+            <app-confirm-button btnClass="btn btn-outline-danger my-2" (confirm)="delete(g)">
+              <fa-icon [icon]="faTrash"></fa-icon>
+              <span>Delete</span>
+            </app-confirm-button>
+          </div>
+        </div>
+      </ng-container> <!-- End card view -->
+
+      <!-- Table view mode -->
+      <ng-container *ngIf="tableView">
+        <div class="col-12">
+          <div class="table-wrapper">
+            <table class="table mt-2 text-left">
+              <tbody>
+                <tr class="bg-dark">
+                  <td class="thin-col sticky-card sticky-header"></td>
+                  <td class="thin-col"></td>
+                  <td class="thin-col"></td>
+                  <td class="thin-col sticky-options sticky-header"></td>
+                  <td class="sticky-name sticky-header">Name</td>
+                  <td>Key</td>
+                  <td>Series</td>
+                  <td>Track</td>
+                  <td>Season</td>
+                  <td>Division</td>
+                  <td>Mode</td>
+                  <td class="date-col">Start Ex.</td>
+                  <td class="date-col">End Ex.</td>
+                  <td class="date-col">Start Reg.</td>
+                  <td class="date-col">End Reg.</td>
+                  <td class="text-right">Team Size</td>
+                  <td class="text-right">Sess. Duration</td>
+                  <td class="text-right">Sess. Limit</td>
+                  <td class="text-right">Space Limit</td>
+                  <td class="text-right">Max Attempts</td>
+                </tr>
+                <tr *ngFor="let game of games; trackBy:trackById">
+                  <td class="thin-col sticky-card sticky-cell"><img [src]="game.cardUrl" class="table-card"></td>
+                  <td class="thin-col">
+                    <fa-icon [icon]="game.isPublished ? faGlobe : faEyeSlash" [class.text-success1]="game.isPublished"></fa-icon>
+                    <fa-icon [icon]="game.allowReset ? faUndo : faLock"></fa-icon>
+                  </td>
+                  <td class="thin-col">
+                    <fa-icon [icon]="game.allowTeam ? faTeam : faUser"></fa-icon>
+                    <fa-icon [icon]="!!game.feedbackTemplate?.challenge?.length || !!game.feedbackTemplate?.game?.length ? faChartBar : faCommentSlash"></fa-icon>
+                  </td>
+                  <td class="thin-col sticky-options sticky-cell">
+                    <div dropdown class="btn-group" container="body" #dropdown="bs-dropdown" [autoClose]="true" [insideClick]="true">
+                      <a class="btn btn-outline-info py-1 px-2" [routerLink]="['../designer', game.id]">
+                        <fa-icon [icon]="faCog" size="sm"></fa-icon>
+                      </a>
+                      <button dropdownToggle class="btn btn-outline-info py-1 px-2 dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                      </button>
+                      <div *dropdownMenu class="dropdown-menu">
+                        <a class="dropdown-item px-3" [routerLink]="['../registrar', game.id]"><fa-icon class="mr-1" [icon]="faUsers"></fa-icon>Players</a>
+                        <a class="dropdown-item px-3" [routerLink]="['../observer/challenges', game.id]"><fa-icon class="mr-1" [icon]="faTv"></fa-icon>Observe</a>
+                        <a class="dropdown-item px-3" [routerLink]="['../designer', game.id]"><fa-icon class="mr-1" [icon]="faCog"></fa-icon>Settings</a>
+                        <div class="dropdown-divider"></div>
+                        <a class="dropdown-item px-3" (click)="clone(game)"><fa-icon class="mr-1" [icon]="faClone"></fa-icon>Clone</a>
+                        <a class="dropdown-item px-3" (click)="yaml(game); dropdown.isOpen = false;"><fa-icon class="mr-1" [icon]="faCopy"></fa-icon>YAML</a>
+                        <a class="dropdown-item px-3" (click)="json(game); dropdown.isOpen = false;"><fa-icon class="mr-1" [icon]="faCopy"></fa-icon>JSON</a>
+                        <div class="dropdown-divider"></div>
+                        <app-confirm-button btnClass="dropdown-item px-3" (confirm)="delete(game)">
+                          <fa-icon [icon]="faTrash"></fa-icon>
+                          <span>Delete</span>
+                        </app-confirm-button>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="sticky-name sticky-cell name-col">
+                    <div class="pr-1 d-flex flex-column">
+                      <span>{{game.name}}</span>
+                      <small class="text-muted">{{game.id | slice:0:12}}</small>
+                    </div>
+                  </td>
+                  <td>{{game.key}}</td>
+                  <td>{{game.competition}}</td>
+                  <td>{{game.track}}</td>
+                  <td>{{game.season}}</td>
+                  <td>{{game.division}}</td>
+                  <td>{{game.mode}}</td>
+                  <td class="date-col">{{game.gameStart | shorttime}}</td>
+                  <td class="date-col">{{game.gameEnd | shorttime}}</td>
+                  <td class="date-col">{{game.registrationOpen | shorttime}}</td>
+                  <td class="date-col">{{game.registrationClose | shorttime}}</td>
+                  <td class="text-right">{{game.minTeamSize}}-{{game.maxTeamSize}}</td>
+                  <td class="text-right">{{game.sessionMinutes}}m</td>
+                  <td class="text-right">{{game.sessionLimit}}</td>
+                  <td class="text-right">{{game.gamespaceLimitPerSession}}</td>
+                  <td class="text-right">{{game.maxAttempts}}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </ng-container> <!-- End table view -->
+
+    </ng-container>
 
   <!-- </div> -->
   <div class="my-4"></div>

--- a/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.scss
+++ b/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.scss
@@ -5,13 +5,17 @@
 }
 .overlay {
   position: absolute;
-  top: 1rem;
-  bottom: 1rem;
-  left: 1rem;
-  right: 1rem;
+  top: 0rem;
+  bottom: 0rem;
+  left: 0rem;
+  right: 0rem;
   border-radius: .25rem;
   background-color: rgba(black, .8);
   z-index: 10;
+}
+.dropzone {
+  border-radius: 0;
+  border: 0;
 }
 
 .table-wrapper {

--- a/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.scss
+++ b/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.scss
@@ -1,3 +1,5 @@
+@import '../../../scss/variables';
+
 .wrapper {
   // position: relative;
 }
@@ -10,4 +12,82 @@
   border-radius: .25rem;
   background-color: rgba(black, .8);
   z-index: 10;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  overflow-y: none;
+  background-color: $body-bg;
+}
+table {
+  border-collapse: separate; 
+  border-spacing: 0; 
+}
+
+td {
+  vertical-align: middle;
+}
+td:not(.thin-col) {
+  min-width: 80px;
+  max-width: 300px;
+  padding: 0.5rem;
+  word-wrap: break-word;
+}
+td.thin-col {
+  padding-left: 5px;
+  padding-right: 5px;
+  text-align: center;
+}
+td.name-col {
+  min-width: 250px;
+  max-width: 350px;
+}
+
+td.date-col {
+  min-width: 120px;
+}
+
+// 3 'sticky' columns to never scroll out of view
+.sticky-card {
+  position: sticky; 
+  left: 0; 
+}
+.sticky-options {
+  position: sticky; 
+  left: 45px; 
+  z-index: 30;
+}
+.sticky-name {
+  position: sticky;
+  left: 112px;
+  div {
+    border-right: #444 solid 1px;
+  }
+}
+.sticky-cell {
+  background-color: $body-bg;
+}
+.sticky-header {
+  background-color: $dark;
+}
+
+.table-card {
+  height: 50px;
+  padding: 0;
+  margin: 0;
+}
+
+.dropdown-item {
+  cursor: pointer;
+}
+
+// for table scroll bar to match theme
+.table-wrapper::-webkit-scrollbar {
+  background: $black; 
+}
+.table-wrapper::-webkit-scrollbar-thumb {
+  background: $dark; 
+}
+.table-wrapper::-webkit-scrollbar-thumb:hover {
+  background: darken($dark, 5%); 
 }

--- a/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.ts
+++ b/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.ts
@@ -3,7 +3,7 @@
 
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { faArrowLeft, faPlus, faCopy, faTrash, faEdit, faUsers, faUser, faUsersCog, faCog, faTv, faToggleOff, faToggleOn, faEyeSlash, faUndo, faGlobeAmericas, faClone, faChartBar, faCommentSlash, faLock } from '@fortawesome/free-solid-svg-icons';
+import { faArrowLeft, faPlus, faCopy, faTrash, faEdit, faUsers, faUser, faUsersCog, faCog, faTv, faToggleOff, faToggleOn, faEyeSlash, faUndo, faGlobeAmericas, faClone, faChartBar, faCommentSlash, faLock, faGamepad } from '@fortawesome/free-solid-svg-icons';
 import { BehaviorSubject, Subject, Observable } from 'rxjs';
 import { debounceTime, switchMap, tap, mergeMap } from 'rxjs/operators';
 import { Game, NewGame } from '../../api/game-models';
@@ -39,6 +39,7 @@ export class DashboardComponent implements OnInit {
   faUsers = faUsersCog;
   faCog = faCog;
   faTv = faTv;
+  faGamepad = faGamepad; // game lobby
   faToggleOn = faToggleOn; // on table view
   faToggleOff = faToggleOff; // on card view
   faEyeSlash = faEyeSlash; // unpublished game

--- a/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.ts
+++ b/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.ts
@@ -3,7 +3,7 @@
 
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { faArrowLeft, faPlus, faCopy, faTrash, faEdit, faUsers, faUsersCog, faCog, faTv } from '@fortawesome/free-solid-svg-icons';
+import { faArrowLeft, faPlus, faCopy, faTrash, faEdit, faUsers, faUser, faUsersCog, faCog, faTv, faToggleOff, faToggleOn, faEyeSlash, faUndo, faGlobeAmericas, faClone, faChartBar, faCommentSlash, faLock } from '@fortawesome/free-solid-svg-icons';
 import { BehaviorSubject, Subject, Observable } from 'rxjs';
 import { debounceTime, switchMap, tap, mergeMap } from 'rxjs/operators';
 import { Game, NewGame } from '../../api/game-models';
@@ -23,18 +23,32 @@ export class DashboardComponent implements OnInit {
   created$: Observable<NewGame>;
   games$: Observable<Game[]>;
   games: Game[] = [];
-  // game: any;
+
+  preferenceKey = 'admin.dashboard.game.viewer.mode'; // key to save toggle in local storage
+  tableView: boolean; // true = table, false = cards
+
   search: Search = { term: '' };
   hot!: Game | null;
 
   faArrowLeft = faArrowLeft;
   faPlus = faPlus;
   faCopy = faCopy;
+  faClone = faClone;
   faTrash = faTrash;
   faEdit = faEdit;
   faUsers = faUsersCog;
   faCog = faCog;
   faTv = faTv;
+  faToggleOn = faToggleOn; // on table view
+  faToggleOff = faToggleOff; // on card view
+  faEyeSlash = faEyeSlash; // unpublished game
+  faGlobe = faGlobeAmericas; // published game
+  faUser = faUser; // individual game
+  faTeam = faUsers; // team game
+  faUndo = faUndo; // allow reset 
+  faLock = faLock; // don't allow reset
+  faChartBar = faChartBar; // has feedback configured
+  faCommentSlash = faCommentSlash; // doesn't have feedback configured
 
   constructor(
     private api: GameService,
@@ -53,7 +67,9 @@ export class DashboardComponent implements OnInit {
       tap(m => this.games.unshift(m)),
       tap(m => this.select(m))
     );
-
+    // use local storage to keep toggle preference when returning to dashboard for continuity
+    // default to false (card view) when no preference stored yet
+    this.tableView = window.localStorage[this.preferenceKey] == 'true' ? true : false;
   }
 
   ngOnInit(): void {
@@ -129,5 +145,10 @@ export class DashboardComponent implements OnInit {
   }
   off(g: Game): void {
     this.hot = null;
+  }
+
+  toggleViewMode() {
+    this.tableView = !this.tableView;
+    window.localStorage[this.preferenceKey] = this.tableView;
   }
 }

--- a/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.html
+++ b/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.html
@@ -61,32 +61,47 @@
 
         <div class="form-group pb-0 pt-1">
           <label for="competition-input">Series</label>
-          <input type="text" class="form-control" id="competition-input" name="competition"
+          <input type="text" list="competition-list" class="form-control" id="competition-input" name="competition"
                  [(ngModel)]="game.competition">
+          <datalist id="competition-list">
+            <option *ngFor="let o of suggestions.competition | keyvalue: sortByCount;" [value]="o.key">
+          </datalist>
           <small>links this event to others in the series</small>
         </div>
 
         <div class="form-group pb-0 pt-1">
           <label for="track-input">Track</label>
-          <input type="text" class="form-control" id="track-input" name="track" [(ngModel)]="game.track">
+          <input type="text" list="track-list" class="form-control" id="track-input" name="track" [(ngModel)]="game.track">
+          <datalist id="track-list">
+            <option *ngFor="let o of suggestions.track | keyvalue: sortByCount;" [value]="o.key">
+          </datalist>
           <small>distinguish which track of the series</small>
         </div>
 
         <div class="form-group pb-0 pt-1">
           <label for="season-input">Season</label>
-          <input type="text" class="form-control" id="season-input" name="season" [(ngModel)]="game.season">
+          <input type="text" list="season-list" class="form-control" id="season-input" name="season" [(ngModel)]="game.season">
+          <datalist id="season-list">
+            <option *ngFor="let o of suggestions.season | keyvalue: sortByCount;" [value]="o.key">
+          </datalist>
           <small>links this event to others in this series season</small>
         </div>
 
         <div class="form-group pb-0 pt-1">
           <label for="division-input">Division</label>
-          <input type="text" class="form-control" id="division-input" name="division" [(ngModel)]="game.division">
+          <input type="text" list="division-list" class="form-control" id="division-input" name="division" [(ngModel)]="game.division">
+          <datalist id="division-list">
+            <option *ngFor="let o of suggestions.division | keyvalue: sortByCount;" [value]="o.key">
+          </datalist>
           <small>specify the attended audience level (i.e. Open, Amatuer, Pro, etc.) </small>
         </div>
 
         <div class="form-group pb-0 pt-1">
           <label for="mode-input">Mode</label>
-          <input type="text" class="form-control" id="mode-input" name="mode" [(ngModel)]="game.mode">
+          <input type="text" list="mode-list" class="form-control" id="mode-input" name="mode" [(ngModel)]="game.mode">
+          <datalist id="mode-list">
+            <option *ngFor="let o of suggestions.mode | keyvalue: sortByCount;" [value]="o.key">
+          </datalist>
           <small>specify the game mode (i.e. vm, unity, offline) </small>
         </div>
 
@@ -106,19 +121,28 @@
 
         <div class="form-group pb-0 pt-1">
           <label for="cardtext1-input">Card Text Top</label>
-          <input type="text" class="form-control" id="cardtext1-input" name="cardText1" [(ngModel)]="game.cardText1">
+          <input type="text" list="cardText1-list" class="form-control" id="cardtext1-input" name="cardText1" [(ngModel)]="game.cardText1">
+          <datalist id="cardText1-list">
+            <option *ngFor="let o of suggestions.cardText1 | keyvalue: sortByCount;" [value]="o.key">
+          </datalist>
           <small>text displayed at the top of the card</small>
         </div>
 
         <div class="form-group pb-0 pt-1">
           <label for="cardtext2-input">Card Text Middle</label>
-          <input type="text" class="form-control" id="cardtext2-input" name="cardText2" [(ngModel)]="game.cardText2">
+          <input type="text" list="cardText2-list" class="form-control" id="cardtext2-input" name="cardText2" [(ngModel)]="game.cardText2">
+          <datalist id="cardText2-list">
+            <option *ngFor="let o of suggestions.cardText2 | keyvalue: sortByCount;" [value]="o.key">
+          </datalist>
           <small>text displayed in the middle of the card</small>
         </div>
 
         <div class="form-group pb-0 pt-1">
           <label for="cardtext3-input">Card Text Bottom</label>
-          <input type="text" class="form-control" id="cardtext3-input" name="cardText3" [(ngModel)]="game.cardText3">
+          <input type="text" list="cardText3-list" class="form-control" id="cardtext3-input" name="cardText3" [(ngModel)]="game.cardText3">
+          <datalist id="cardText3-list">
+            <option *ngFor="let o of suggestions.cardText3 | keyvalue: sortByCount;" [value]="o.key">
+          </datalist>
           <small>text displayed at the bottom of the card</small>
         </div>
       </div>

--- a/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.ts
+++ b/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.ts
@@ -10,6 +10,7 @@ import { Game } from '../../api/game-models';
 import { GameService } from '../../api/game.service';
 import { ConfigService } from '../../utility/config.service';
 import { ActivatedRoute, Router } from '@angular/router';
+import { KeyValue } from '@angular/common';
 
 @Component({
   selector: 'app-game-editor',
@@ -29,6 +30,18 @@ export class GameEditorComponent implements OnInit, AfterViewInit {
   feedbackWarning: boolean = false;
   viewing = 1;
 
+  // store unique values of each game field with their frequencies for ordered suggestion lists
+  suggestions = {
+    competition: new Map<string,number>(), 
+    track: new Map<string,number>(), 
+    season: new Map<string,number>(), 
+    division: new Map<string,number>(), 
+    mode: new Map<string,number>(), 
+    cardText1: new Map<string,number>(), 
+    cardText2: new Map<string,number>(), 
+    cardText3: new Map<string,number>()
+  };
+  
   faCaretDown = faCaretDown;
   faCaretRight = faCaretRight;
   faToggleOn = faToggleOn;
@@ -45,6 +58,12 @@ export class GameEditorComponent implements OnInit, AfterViewInit {
     private api: GameService,
     private config: ConfigService
   ) {
+
+    // one-time get list of all games for field suggestions
+    api.list({}).subscribe(
+      games => this.addSuggestions(games)
+    );
+
     this.game$ = route.params.pipe(
       map(p => p.id),
       filter(id => !!id),
@@ -107,6 +126,26 @@ export class GameEditorComponent implements OnInit, AfterViewInit {
   }
 
   
+  addSuggestions(games: Game[]) {
+    // add properties of each game into respective map to record distinct values and maintain counts
+    for (const game of games) {
+      this.countGameField(this.suggestions.competition, game.competition);
+      this.countGameField(this.suggestions.track, game.track);
+      this.countGameField(this.suggestions.season, game.season);
+      this.countGameField(this.suggestions.division, game.division);
+      this.countGameField(this.suggestions.mode, game.mode);
+      this.countGameField(this.suggestions.cardText1, game.cardText1);
+      this.countGameField(this.suggestions.cardText1, game.cardText1);
+      this.countGameField(this.suggestions.cardText1, game.cardText1);
+    }
+  }
+
+  countGameField(fieldMap: Map<string, number>, value: string) {
+    // if field value not blank, increment occurrence count by 1
+    if (!!value)
+      fieldMap.set(value, (fieldMap.get(value) ?? 0) + 1);
+  }
+
   updateFeedbackMessage() {
     this.feedbackWarning = false;
     if (!this.game.feedbackConfig || this.game.feedbackConfig.trim().length == 0) {
@@ -131,6 +170,16 @@ export class GameEditorComponent implements OnInit, AfterViewInit {
       return false;
     }
     return true;
+  }
+
+  sortByCount(a: KeyValue<string, number>, b: KeyValue<string, number>) {
+    // order DESC by occurrence count
+    if (a.value < b.value) return 1;
+    if (a.value > b.value) return -1;
+    // order ASC alphabetically by name for occurrence tie
+    if (a.key < b.key) return -1;
+    if (a.key > b.key) return 1;
+    return 0;
   }
 
 }

--- a/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.ts
+++ b/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.ts
@@ -83,7 +83,7 @@ export class GameEditorComponent implements OnInit, AfterViewInit {
     this.updated$ = this.form.valueChanges.pipe(
       filter(f => !this.form.pristine && (this.form.valid || false)),
       tap(g => this.dirty = true),
-      debounceTime(5000),
+      debounceTime(500),
       switchMap(g => this.api.update(this.game)),
       tap(r => this.dirty = false),
       filter(f => this.refreshFeedback),

--- a/projects/gameboard-ui/src/app/api/game-models.ts
+++ b/projects/gameboard-ui/src/app/api/game-models.ts
@@ -69,7 +69,7 @@ export enum GameRegistrationType {
   domain = 'domain'
 }
 
-export interface  GameGroup {
+export interface GameGroup {
   year: number;
   month: number;
   monthName: string;

--- a/projects/gameboard-ui/src/app/api/game-models.ts
+++ b/projects/gameboard-ui/src/app/api/game-models.ts
@@ -69,6 +69,13 @@ export enum GameRegistrationType {
   domain = 'domain'
 }
 
+export interface  GameGroup {
+  year: number;
+  month: number;
+  monthName: string;
+  games: Game[];
+}
+
 export interface UploadedFile {
   filename: string;
 }

--- a/projects/gameboard-ui/src/app/api/game.service.ts
+++ b/projects/gameboard-ui/src/app/api/game.service.ts
@@ -7,7 +7,7 @@ import { Observable, of } from 'rxjs';
 import { debounceTime, map, tap } from 'rxjs/operators';
 import { ConfigService } from '../utility/config.service';
 import { ChallengeGate } from './board-models';
-import { ChangedGame, Game, NewGame, SessionForecast, UploadedFile } from './game-models';
+import { ChangedGame, Game, GameGroup, NewGame, SessionForecast, UploadedFile } from './game-models';
 import { TimeWindow } from './player-models';
 import { Spec } from './spec-models';
 
@@ -28,6 +28,18 @@ export class GameService {
     return this.http.get<Game[]>(this.url + '/games', { params: filter }).pipe(
       map(r => {
         r.forEach(g => this.transform(g));
+        return r;
+      })
+    );
+  }
+
+  public listGrouped(filter: any): Observable<GameGroup[]> {
+    return this.http.get<GameGroup[]>(this.url + '/games/grouped', { params: filter }).pipe(
+      map(r => {
+        r.forEach(c => {
+          c.monthName = this.monthName(c.month);
+          c.games.forEach(g => this.transform(g))
+        });
         return r;
       })
     );
@@ -138,6 +150,13 @@ export class GameService {
 
     return game;
   }
+
+  private monthName(monthNum: number) {
+    if (!monthNum || monthNum < 1 || monthNum > 12)
+      return '';
+    return ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'][monthNum - 1];
+  }
+
 }
 export class CachedGame {
   id: string;

--- a/projects/gameboard-ui/src/app/app.module.ts
+++ b/projects/gameboard-ui/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
@@ -32,6 +33,7 @@ import { UtilityModule } from './utility/utility.module';
     AppRoutingModule,
     ApiModule,
     UtilityModule,
+    TooltipModule.forRoot(),
     ButtonsModule.forRoot(),
     BsDropdownModule.forRoot(),
     MarkdownModule.forRoot({

--- a/projects/gameboard-ui/src/app/app.module.ts
+++ b/projects/gameboard-ui/src/app/app.module.ts
@@ -5,8 +5,10 @@ import { HttpClient, HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common
 import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
+import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
 import { Observable } from 'rxjs';
 import { ApiModule } from './api/api.module';
@@ -24,12 +26,14 @@ import { UtilityModule } from './utility/utility.module';
   ],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     FormsModule,
     HttpClientModule,
     AppRoutingModule,
     ApiModule,
     UtilityModule,
     ButtonsModule.forRoot(),
+    BsDropdownModule.forRoot(),
     MarkdownModule.forRoot({
       loader: HttpClient,
       markedOptions: {
@@ -44,6 +48,7 @@ import { UtilityModule } from './utility/utility.module';
     UtilityModule,
     FontAwesomeModule,
     ButtonsModule,
+    BsDropdownModule,
     MarkdownModule
   ],
   providers: [

--- a/projects/gameboard-ui/src/app/game/game-info/game-info.component.html
+++ b/projects/gameboard-ui/src/app/game/game-info/game-info.component.html
@@ -8,11 +8,11 @@
       <div class="lead mt-4">Execution</div>
       <div class="row px-2 mx-0 border-top border-dark">
         <div class="col-6 p-2 font-weight-bold">Starts</div>
-        <div class="col-6 p-2">{{game.gameStart | shorttime}}</div>
+        <div class="col-6 p-2">{{game.gameStart | shorttime:true}}</div>
       </div>
       <div class="row px-2 mx-0 border-top border-dark">
         <div class="col-6 p-2 font-weight-bold">Ends</div>
-        <div class="col-6 p-2">{{game.gameEnd | shorttime}}</div>
+        <div class="col-6 p-2">{{game.gameEnd | shorttime:true}}</div>
       </div>
       <div class="row px-2 mx-0 border-top border-dark">
         <div class="col-6 p-2 font-weight-bold">Session</div>
@@ -22,11 +22,11 @@
       <div class="lead mt-4">Registration</div>
       <div class="row px-2 mx-0 border-top border-dark">
         <div class="col-6 p-2 font-weight-bold">Opens</div>
-        <div class="col-6 p-2">{{game.registrationOpen | shorttime}}</div>
+        <div class="col-6 p-2">{{game.registrationOpen | shorttime:true}}</div>
       </div>
       <div class="row px-2 mx-0 border-top border-dark">
         <div class="col-6 p-2 font-weight-bold">Closes</div>
-        <div class="col-6 p-2">{{game.registrationClose | shorttime}}</div>
+        <div class="col-6 p-2">{{game.registrationClose | shorttime:true}}</div>
       </div>
       <div class="row px-2 mx-0 border-top border-dark">
         <div class="col-6 p-2 font-weight-bold">Access</div>

--- a/projects/gameboard-ui/src/app/game/game-info/game-info.component.html
+++ b/projects/gameboard-ui/src/app/game/game-info/game-info.component.html
@@ -6,30 +6,37 @@
     <div class="card-body">
 
       <div class="lead mt-4">Execution</div>
-
-      <table class="table">
-        <tbody>
-          <tr><th>Starts</th><td>{{game.gameStart}}</td></tr>
-          <tr><th>Ends</th><td>{{game.gameEnd}}</td></tr>
-          <tr><th>Session</th><td>{{game.sessionMinutes}} minutes</td></tr>
-        </tbody>
-      </table>
+      <div class="row px-2 mx-0 border-top border-dark">
+        <div class="col-6 p-2 font-weight-bold">Starts</div>
+        <div class="col-6 p-2">{{game.gameStart | shorttime}}</div>
+      </div>
+      <div class="row px-2 mx-0 border-top border-dark">
+        <div class="col-6 p-2 font-weight-bold">Ends</div>
+        <div class="col-6 p-2">{{game.gameEnd | shorttime}}</div>
+      </div>
+      <div class="row px-2 mx-0 border-top border-dark">
+        <div class="col-6 p-2 font-weight-bold">Session</div>
+        <div class="col-6 p-2">{{game.sessionMinutes}} minutes</div>
+      </div>
 
       <div class="lead mt-4">Registration</div>
+      <div class="row px-2 mx-0 border-top border-dark">
+        <div class="col-6 p-2 font-weight-bold">Opens</div>
+        <div class="col-6 p-2">{{game.registrationOpen | shorttime}}</div>
+      </div>
+      <div class="row px-2 mx-0 border-top border-dark">
+        <div class="col-6 p-2 font-weight-bold">Closes</div>
+        <div class="col-6 p-2">{{game.registrationClose | shorttime}}</div>
+      </div>
+      <div class="row px-2 mx-0 border-top border-dark">
+        <div class="col-6 p-2 font-weight-bold">Access</div>
+        <div class="col-6 p-2 text-capitalize">{{game.registrationType}}</div>
+      </div>
+      <div class="row px-2 mx-0 border-top border-dark">
+        <div class="col-6 p-2 font-weight-bold">Team Size</div>
+        <div class="col-6 p-2">{{game.allowTeam ? (game.minTeamSize || 1)+" - "+(game.maxTeamSize || 1) : "Individual"}}</div>
+      </div>
 
-      <table class="table">
-        <tbody>
-          <tr><th>Access</th><td>{{game.registrationType}}</td></tr>
-          <tr><th>Opens</th><td>{{game.registrationOpen}}</td></tr>
-          <tr><th>Closes</th><td>{{game.registrationClose}}</td></tr>
-          <tr><th>Constraint</th><td>{{game.registrationConstraint}}</td></tr>
-          <tr><th>Min Team Size</th><td>{{game.minTeamSize}}</td></tr>
-          <tr><th>Max Team Size</th><td>{{game.maxTeamSize}}</td></tr>
-          <tr><th>Require same-sponsor team</th><td>{{game.requireSponsoredTeam}}</td></tr>
-        </tbody>
-      </table>
-
-      <!-- <pre>{{game | yaml}}</pre> -->
     </div>
   </div>
 </ng-container>

--- a/projects/gameboard-ui/src/app/game/game-info/game-info.component.html
+++ b/projects/gameboard-ui/src/app/game/game-info/game-info.component.html
@@ -4,14 +4,6 @@
 <ng-container *ngIf="game">
   <div class="card">
     <div class="card-body">
-      <!-- <div class="card-title lead text-success">
-        {{game.competition}} &nbsp;
-        {{game.season}} &nbsp;
-        {{game.track}} &nbsp;
-        {{game.division}} &nbsp;
-        {{game.name}} &nbsp;
-      </div> -->
-      <!-- <div class="lead">Overview</div> -->
 
       <div class="lead mt-4">Execution</div>
 

--- a/projects/gameboard-ui/src/app/game/game-page/game-page.component.html
+++ b/projects/gameboard-ui/src/app/game/game-page/game-page.component.html
@@ -27,7 +27,7 @@
       <markdown [data]="ctx.game.gameMarkdown"></markdown>
     </div>
 
-    <div class="row justify-content-center">
+    <div class="row justify-content-start">
       <!-- if auth'd -->
       <ng-container *ngIf="!!ctx.user.id">
         <!-- if enrolled -->
@@ -46,7 +46,7 @@
         </ng-container>
 
       </ng-container>
-      <div class="col panel">
+      <div class="col panel max-half">
         <h2>Info</h2>
         <app-game-info [game]="ctx.game"></app-game-info>
       </div>

--- a/projects/gameboard-ui/src/app/game/game-page/game-page.component.scss
+++ b/projects/gameboard-ui/src/app/game/game-page/game-page.component.scss
@@ -16,3 +16,6 @@
 .scoreboard {
   min-height: 600px;
 }
+.max-half {
+  max-width: 50%;
+}

--- a/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.html
+++ b/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.html
@@ -8,10 +8,6 @@
       <img [src]="ctx.game.cardUrl" class="img-fluid" alt="{{ctx.game.name}} logo">
     </a>
     <span class="text-success mx-4">
-      {{ctx.game.competition}}
-      {{ctx.game.season}}
-      {{ctx.game.track}}
-      {{ctx.game.division}}
       {{ctx.game.name}}
     </span>
     <div class="spacer"></div>

--- a/projects/gameboard-ui/src/app/game/scoreboard-page/scoreboard-page.component.html
+++ b/projects/gameboard-ui/src/app/game/scoreboard-page/scoreboard-page.component.html
@@ -7,10 +7,6 @@
       <img [src]="game.cardUrl" class="img-fluid" alt="{{game.name}} logo">
     </a>
     <span class="text-success mx-4">
-      {{game.competition}}
-      {{game.season}}
-      {{game.track}}
-      {{game.division}}
       {{game.name}}
     </span>
   </div>

--- a/projects/gameboard-ui/src/app/home/landing/landing.component.html
+++ b/projects/gameboard-ui/src/app/home/landing/landing.component.html
@@ -8,10 +8,9 @@
     <div class="col-12 mx-0 px-0 mb-2">
       <h2>Live!</h2>
     </div>
-    <app-game-card *ngFor="let g of present"
-      [game]="g" (selected)="selected(g)"
-      class="col-lg-3 col-md-4 col-6 mb-4">
-    </app-game-card>
+    <ng-container *ngFor="let game of present">
+      <ng-container *ngTemplateOutlet="gameWrapper;context: {game: game}"></ng-container>
+    </ng-container>
   </ng-container>
 
 </div>
@@ -29,10 +28,9 @@
         <div class="border-dark my-3 group-line"></div>
       </h3>
     </div>
-    <app-game-card *ngFor="let g of group.games"
-      [game]="g" (selected)="selected($event)"
-      class="col-lg-3 col-md-4 col-6 mb-4">
-    </app-game-card>
+    <ng-container *ngFor="let game of group.games">
+      <ng-container *ngTemplateOutlet="gameWrapper;context: {game: game}"></ng-container>
+    </ng-container>
   </ng-container>
 </div>
 
@@ -49,12 +47,36 @@
         <div class="border-dark my-3 group-line"></div>
       </h3>
     </div>
-    <app-game-card *ngFor="let g of group.games"
-      [game]="g" (selected)="selected($event)"
-      class="col-lg-3 col-md-4 col-6 mb-4">
-    </app-game-card>
+    <ng-container *ngFor="let game of group.games">
+      <ng-container *ngTemplateOutlet="gameWrapper;context: {game: game}"></ng-container>
+    </ng-container>
   </ng-container>
 </div>
+
+<!-- game wrapper template  -->
+<ng-template #gameWrapper let-game="game">
+  <div class="card-wrapper col-lg-3 col-md-4 col-6 mb-4" tabindex="0">
+    <div class="hover-wrapper" (mouseenter)="on(game)" (mouseleave)="off(game)" (focus)="on(game)">
+      <app-game-card [game]="game"> 
+      </app-game-card> 
+      <div class="overlay py-4 px-4 d-flex" *ngIf="hot===game">
+        <div class="rounded text-center py-3 px-2 mx-3 my-auto w-100">
+          <h5 class="mb-0 font-weight-bold">Registration<fa-icon [icon]="faUserPlus" class="ml-2"></fa-icon></h5>
+          <p *ngIf="game.registration.isBefore">Starts in {{game.registrationOpen | until}}</p>
+          <p *ngIf="game.registration.isDuring">Ends in {{game.registrationClose | until}}</p>
+          <p *ngIf="game.registration.isAfter">Ended {{game.registrationClose | ago}}</p>
+          <h5 class="mb-0 font-weight-bold">Competition<fa-icon [icon]="faGamepad" class="ml-2"></fa-icon></h5>
+          <p class="mb-0 pb-0" *ngIf="game.session.isBefore">Starts in {{game.gameStart | until}}</p>
+          <p class="mb-0 pb-0" *ngIf="game.session.isDuring">Ends in {{game.gameEnd | until}}</p>
+          <p class="mb-0 pb-0" *ngIf="game.session.isAfter">Ended {{game.gameEnd | ago}}</p>
+          <button class="btn btn-outline-success btn-lg mx-1 mt-4 open-button" (click)="selected(game)">
+            <h2 class="p-0 m-0 font-weight-bold">Open Game</h2>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</ng-template>
 
 <ng-template #loading>
   <div class="text-center">

--- a/projects/gameboard-ui/src/app/home/landing/landing.component.html
+++ b/projects/gameboard-ui/src/app/home/landing/landing.component.html
@@ -32,8 +32,8 @@
 <div class="row mt-4" *ngIf="present$ | async as present; else loading">
 
   <ng-container *ngIf="!!present.length">
-    <div class="col-12">
-      <h4>Live!</h4>
+    <div class="col-12 mx-0 px-0">
+      <h2>Live!</h2>
     </div>
     <app-game-card *ngFor="let g of present"
       [game]="g" (selected)="selected(g)"
@@ -46,8 +46,8 @@
 <!-- Upcoming -->
 <div class="row mt-4" *ngIf="future$ | async as future; else loading">
 
-  <div class="col-12">
-    <h4>Upcoming Games</h4>
+  <div class="col-12  mx-0 px-0">
+    <h2>Upcoming Games</h2>
   </div>
 
   <app-game-card *ngFor="let g of future"
@@ -59,15 +59,21 @@
 
 <!-- past -->
 <div class="row mt-4" *ngIf="past$ | async as past; else loading">
-
-  <div class="col-12">
-    <h4>Completed Games</h4>
+  <div class="col-12 mx-0 px-0">
+    <h2>Completed Games</h2>
   </div>
-
-  <app-game-card *ngFor="let g of past"
-    [game]="g" (selected)="selected($event)"
-    class="col-lg-3 col-md-4 col-6 mb-4">
-  </app-game-card>
+  <ng-container *ngFor="let group of past">
+    <div class="col-12 mt-2 mb-1">
+      <h3 class="border-bottom border-dark pb-2">
+        <span class="badge badge-dark group-badge text-white p-2">{{group.monthName}} {{group.year}}</span> 
+        <span class="ml-3 align-self-center group-count">{{group.games.length}}</span>
+      </h3>
+    </div>
+    <app-game-card *ngFor="let g of group.games"
+      [game]="g" (selected)="selected($event)"
+      class="col-lg-3 col-md-4 col-6 mb-4">
+    </app-game-card>
+  </ng-container>
 
 </div>
 

--- a/projects/gameboard-ui/src/app/home/landing/landing.component.html
+++ b/projects/gameboard-ui/src/app/home/landing/landing.component.html
@@ -1,8 +1,21 @@
 <!-- Copyright 2021 Carnegie Mellon University. All Rights Reserved. -->
 <!-- Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information. -->
 
+<!-- Search Bar -->
+<div *ngIf="showSearchBar" class="row mt-4 mb-0">
+  <div class="input-group input-group-sm col-5 ml-auto">
+    <div class="input-group-prepend">
+      <span class="input-group-text">
+        <fa-icon [icon]="faSearch"></fa-icon>
+      </span>
+    </div>
+    <input type="search" [(ngModel)]="searchText" placeholder="term" class="form-control border-0"
+      (input)="typing($event)">
+  </div>
+</div>
+
 <!-- Live -->
-<div class="row mt-4" *ngIf="present$ | async as present; else loading">
+<div class="row mt-1" *ngIf="present$ | async as present; else loading">
 
   <ng-container *ngIf="!!present.length">
     <div class="col-12 mx-0 px-0 mb-2">

--- a/projects/gameboard-ui/src/app/home/landing/landing.component.html
+++ b/projects/gameboard-ui/src/app/home/landing/landing.component.html
@@ -1,38 +1,11 @@
 <!-- Copyright 2021 Carnegie Mellon University. All Rights Reserved. -->
 <!-- Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information. -->
 
-<!-- <div class="card-deck">
-  <div class="card">
-    <img src="..." class="card-img-top" alt="...">
-    <div class="card-body">
-      <h5 class="card-title">Card title</h5>
-      <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-      <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
-    </div>
-  </div>
-  <div class="card">
-    <img src="..." class="card-img-top" alt="...">
-    <div class="card-body">
-      <h5 class="card-title">Card title</h5>
-      <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
-      <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
-    </div>
-  </div>
-  <div class="card">
-    <img src="..." class="card-img-top" alt="...">
-    <div class="card-body">
-      <h5 class="card-title">Card title</h5>
-      <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
-      <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
-    </div>
-  </div>
-</div> -->
-
 <!-- Live -->
 <div class="row mt-4" *ngIf="present$ | async as present; else loading">
 
   <ng-container *ngIf="!!present.length">
-    <div class="col-12 mx-0 px-0">
+    <div class="col-12 mx-0 px-0 mb-2">
       <h2>Live!</h2>
     </div>
     <app-game-card *ngFor="let g of present"
@@ -45,16 +18,22 @@
 
 <!-- Upcoming -->
 <div class="row mt-4" *ngIf="future$ | async as future; else loading">
-
-  <div class="col-12  mx-0 px-0">
+  <div class="col-12 mx-0 px-0">
     <h2>Upcoming Games</h2>
   </div>
-
-  <app-game-card *ngFor="let g of future"
-    [game]="g" (selected)="selected(g)"
-    class="col-lg-3 col-md-4 col-6 mb-4">
-  </app-game-card>
-
+  <ng-container *ngFor="let group of future">
+    <div class="col-12 mt-2 mb-0 pb-0 mx-0 pl-1">
+      <h3 class="mb-0 pb-0">
+        <span class="badge badge-dark group-badge text-white p-2">{{group.monthName}} {{group.year}}</span> 
+        <span class="ml-3 align-self-center group-count">{{group.games.length}}</span>
+        <div class="border-dark my-3 group-line"></div>
+      </h3>
+    </div>
+    <app-game-card *ngFor="let g of group.games"
+      [game]="g" (selected)="selected($event)"
+      class="col-lg-3 col-md-4 col-6 mb-4">
+    </app-game-card>
+  </ng-container>
 </div>
 
 <!-- past -->
@@ -63,10 +42,11 @@
     <h2>Completed Games</h2>
   </div>
   <ng-container *ngFor="let group of past">
-    <div class="col-12 mt-2 mb-1">
-      <h3 class="border-bottom border-dark pb-2">
+    <div class="col-12 mt-2 mb-0 pb-0 mx-0 pl-1">
+      <h3 class="mb-0 pb-0">
         <span class="badge badge-dark group-badge text-white p-2">{{group.monthName}} {{group.year}}</span> 
         <span class="ml-3 align-self-center group-count">{{group.games.length}}</span>
+        <div class="border-dark my-3 group-line"></div>
       </h3>
     </div>
     <app-game-card *ngFor="let g of group.games"
@@ -74,7 +54,6 @@
       class="col-lg-3 col-md-4 col-6 mb-4">
     </app-game-card>
   </ng-container>
-
 </div>
 
 <ng-template #loading>

--- a/projects/gameboard-ui/src/app/home/landing/landing.component.html
+++ b/projects/gameboard-ui/src/app/home/landing/landing.component.html
@@ -75,9 +75,9 @@
       <div class="overlay py-4 px-4 d-flex" *ngIf="hot===game">
         <div class="rounded text-center py-3 px-2 mx-3 my-auto w-100">
           <h5 class="mb-0 font-weight-bold">Registration<fa-icon [icon]="faUserPlus" class="ml-2"></fa-icon></h5>
-          <p *ngIf="game.registration.isBefore">Starts in {{game.registrationOpen | until}}</p>
-          <p *ngIf="game.registration.isDuring">Ends in {{game.registrationClose | until}}</p>
-          <p *ngIf="game.registration.isAfter">Ended {{game.registrationClose | ago}}</p>
+          <p *ngIf="game.registration.isBefore">Opens in {{game.registrationOpen | until}}</p>
+          <p *ngIf="game.registration.isDuring">Closes in {{game.registrationClose | until}}</p>
+          <p *ngIf="game.registration.isAfter">Closed {{game.registrationClose | ago}}</p>
           <h5 class="mb-0 font-weight-bold">Competition<fa-icon [icon]="faGamepad" class="ml-2"></fa-icon></h5>
           <p class="mb-0 pb-0" *ngIf="game.session.isBefore">Starts in {{game.gameStart | until}}</p>
           <p class="mb-0 pb-0" *ngIf="game.session.isDuring">Ends in {{game.gameEnd | until}}</p>

--- a/projects/gameboard-ui/src/app/home/landing/landing.component.scss
+++ b/projects/gameboard-ui/src/app/home/landing/landing.component.scss
@@ -1,3 +1,12 @@
 app-game-card {
   cursor: pointer;
 }
+
+.group-count {
+  font-size: 70%;
+}
+.group-badge {
+  font-weight: 800;
+  text-transform: uppercase;
+  border-radius: 2px;
+}

--- a/projects/gameboard-ui/src/app/home/landing/landing.component.scss
+++ b/projects/gameboard-ui/src/app/home/landing/landing.component.scss
@@ -1,6 +1,3 @@
-app-game-card {
-  cursor: pointer;
-}
 
 .group-count {
   font-size: 70%;
@@ -14,4 +11,18 @@ app-game-card {
   width: 90%;
   margin: auto;
   border-bottom: 2px solid;
+}
+
+.overlay {
+  position: absolute;
+  top: 0rem;
+  bottom: 0rem;
+  left: 0rem;
+  right: 0rem;
+  border-radius: .25rem;
+  background-color: rgba(black, .8);
+  z-index: 10;
+}
+.open-button {
+  padding: 2rem 1rem;
 }

--- a/projects/gameboard-ui/src/app/home/landing/landing.component.scss
+++ b/projects/gameboard-ui/src/app/home/landing/landing.component.scss
@@ -10,3 +10,8 @@ app-game-card {
   text-transform: uppercase;
   border-radius: 2px;
 }
+.group-line {
+  width: 90%;
+  margin: auto;
+  border-bottom: 2px solid;
+}

--- a/projects/gameboard-ui/src/app/home/landing/landing.component.ts
+++ b/projects/gameboard-ui/src/app/home/landing/landing.component.ts
@@ -3,6 +3,7 @@
 
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { faGamepad, faUserPlus } from '@fortawesome/free-solid-svg-icons';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
 import { BoardGame } from '../../api/board-models';
@@ -19,6 +20,11 @@ export class LandingComponent implements OnInit {
   past$: Observable<GameGroup[]>;
   present$: Observable<Game[]>;
   future$: Observable<GameGroup[]>;
+
+  hot!: Game | null;
+
+  faGamepad = faGamepad;
+  faUserPlus = faUserPlus;
 
   constructor(
     private router: Router,
@@ -44,4 +50,13 @@ export class LandingComponent implements OnInit {
   selected(game: Game | BoardGame): void {
     this.router.navigate(['/game', game.id]);
   }
+
+  on(g: Game): void {
+    this.hot = g;
+  }
+
+  off(g: Game): void {
+    this.hot = null;
+  }
+
 }

--- a/projects/gameboard-ui/src/app/home/landing/landing.component.ts
+++ b/projects/gameboard-ui/src/app/home/landing/landing.component.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
 import { BoardGame } from '../../api/board-models';
-import { Game } from '../../api/game-models';
+import { Game, GameGroup } from '../../api/game-models';
 import { GameService } from '../../api/game.service';
 
 @Component({
@@ -16,7 +16,7 @@ import { GameService } from '../../api/game.service';
 })
 export class LandingComponent implements OnInit {
   refresh$ = new BehaviorSubject<any>(true);
-  past$: Observable<Game[]>;
+  past$: Observable<GameGroup[]>;
   present$: Observable<Game[]>;
   future$: Observable<Game[]>;
 
@@ -26,7 +26,7 @@ export class LandingComponent implements OnInit {
   ) {
     this.past$ = this.refresh$.pipe(
       debounceTime(400),
-      switchMap(() => api.list({filter: ['past']}))
+      switchMap(() => api.listGrouped({filter: ['past']}))
     );
     this.present$ = this.refresh$.pipe(
       debounceTime(200),

--- a/projects/gameboard-ui/src/app/home/landing/landing.component.ts
+++ b/projects/gameboard-ui/src/app/home/landing/landing.component.ts
@@ -3,9 +3,9 @@
 
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { faGamepad, faUserPlus } from '@fortawesome/free-solid-svg-icons';
+import { faGamepad, faPlusSquare, faSearch, faUserPlus } from '@fortawesome/free-solid-svg-icons';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { debounceTime, switchMap } from 'rxjs/operators';
+import { debounceTime, switchMap, tap } from 'rxjs/operators';
 import { BoardGame } from '../../api/board-models';
 import { Game, GameGroup } from '../../api/game-models';
 import { GameService } from '../../api/game.service';
@@ -25,6 +25,11 @@ export class LandingComponent implements OnInit {
 
   faGamepad = faGamepad;
   faUserPlus = faUserPlus;
+  faSearch = faSearch;
+  faPlusSquare = faPlusSquare;
+
+  showSearchBar = false;
+  searchText = "";
 
   constructor(
     private router: Router,
@@ -32,15 +37,18 @@ export class LandingComponent implements OnInit {
   ) {
     this.past$ = this.refresh$.pipe(
       debounceTime(400),
-      switchMap(() => api.listGrouped({filter: ['past']}))
+      switchMap(() => api.listGrouped({filter: ['past'], term: this.searchText})),
+      tap(g => {if (g.length > 0) { this.showSearchBar = true} })
     );
     this.present$ = this.refresh$.pipe(
       debounceTime(200),
-      switchMap(() => api.list({filter: ['present']}))
+      switchMap(() => api.list({filter: ['present'], term: this.searchText})),
+      tap(g => {if (g.length > 0) { this.showSearchBar = true} })
     );
     this.future$ = this.refresh$.pipe(
       debounceTime(300),
-      switchMap(() => api.listGrouped({filter: ['future']}))
+      switchMap(() => api.listGrouped({filter: ['future'], term: this.searchText})),
+      tap(g => {if (g.length > 0) { this.showSearchBar = true} })
     );
   }
 
@@ -57,6 +65,10 @@ export class LandingComponent implements OnInit {
 
   off(g: Game): void {
     this.hot = null;
+  }
+
+  typing(e: Event): void {
+    this.refresh$.next(true);
   }
 
 }

--- a/projects/gameboard-ui/src/app/home/landing/landing.component.ts
+++ b/projects/gameboard-ui/src/app/home/landing/landing.component.ts
@@ -18,7 +18,7 @@ export class LandingComponent implements OnInit {
   refresh$ = new BehaviorSubject<any>(true);
   past$: Observable<GameGroup[]>;
   present$: Observable<Game[]>;
-  future$: Observable<Game[]>;
+  future$: Observable<GameGroup[]>;
 
   constructor(
     private router: Router,
@@ -34,7 +34,7 @@ export class LandingComponent implements OnInit {
     );
     this.future$ = this.refresh$.pipe(
       debounceTime(300),
-      switchMap(() => api.list({filter: ['future']}))
+      switchMap(() => api.listGrouped({filter: ['future']}))
     );
   }
 

--- a/projects/gameboard-ui/src/app/utility/components/game-card/game-card.component.html
+++ b/projects/gameboard-ui/src/app/utility/components/game-card/game-card.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright 2021 Carnegie Mellon University. All Rights Reserved. -->
 <!-- Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information. -->
 
-<div class="card bg-dark comp-card h-100" (click)="select()">
+<div class="card bg-dark comp-card h-100 mx-auto" (click)="select()">
   <div class="game-front position-absolute" style="top: 15px; left: 2px;">
     <h2>
       <span class="badge badge-indigo cool-badge m-1 lb-font upper">

--- a/projects/gameboard-ui/src/app/utility/components/game-card/game-card.component.scss
+++ b/projects/gameboard-ui/src/app/utility/components/game-card/game-card.component.scss
@@ -12,6 +12,8 @@
   max-width: 240px;
   max-height: 360px;
   margin: 0;
+  border-radius: 0;
+  border: 0;
 }
 
 .mode-logo {

--- a/projects/gameboard-ui/src/app/utility/pipes/short-time.pipe.ts
+++ b/projects/gameboard-ui/src/app/utility/pipes/short-time.pipe.ts
@@ -5,7 +5,7 @@ export class ShortTimePipe implements PipeTransform {
 
   transform(date: any): string {
     const t = new Date(date);
-    return t.toLocaleTimeString("en-US", { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: 'numeric'});
+    return t.toLocaleTimeString("en-US", { month: 'short', day: '2-digit', year: 'numeric', hour: 'numeric', minute: 'numeric'});
 }
 
 }

--- a/projects/gameboard-ui/src/app/utility/pipes/short-time.pipe.ts
+++ b/projects/gameboard-ui/src/app/utility/pipes/short-time.pipe.ts
@@ -3,9 +3,12 @@ import { Pipe, PipeTransform } from '@angular/core';
 @Pipe({name: 'shorttime'})
 export class ShortTimePipe implements PipeTransform {
 
-  transform(date: any): string {
+  transform(date: any, timeZone: boolean = false): string {
     const t = new Date(date);
-    return t.toLocaleTimeString("en-US", { month: 'short', day: '2-digit', year: 'numeric', hour: 'numeric', minute: 'numeric'});
+    let options = { month: 'short', day: '2-digit', year: 'numeric', hour: 'numeric', minute: 'numeric'} as any
+    if (timeZone)
+      options.timeZoneName = 'shortGeneric';
+    return t.toLocaleTimeString("en-US", options);
 }
 
 }

--- a/projects/gameboard-ui/src/app/utility/pipes/until-date.pipe.ts
+++ b/projects/gameboard-ui/src/app/utility/pipes/until-date.pipe.ts
@@ -1,0 +1,29 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({name: 'until'})
+export class UntilPipe implements PipeTransform {
+    transform(date: any): string {
+        let r = '';
+        const n = new Date(date);
+        const t = new Date();
+        const tag = [ 's', 'm', 'h', 'd' ];
+
+        let d: number = n.valueOf() - t.valueOf();
+        const a: number[] = [
+            d / 1000,
+            d / 1000 / 60,
+            d / 1000 / 60 / 60,
+            d / 1000 / 60 / 60 / 24
+        ];
+        for (let i = 0; i < a.length; i++) {
+            d = Math.floor(a[i]);
+            if (!!d) {
+                r = d + tag[i];
+            }
+        }
+        return r;
+    }
+}

--- a/projects/gameboard-ui/src/app/utility/utility.module.ts
+++ b/projects/gameboard-ui/src/app/utility/utility.module.ts
@@ -9,7 +9,6 @@ import { ErrorDivComponent } from './components/error-div/error-div.component';
 import { SpinnerComponent } from './components/spinner/spinner.component';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { AlertModule } from 'ngx-bootstrap/alert';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { AgedDatePipe } from './pipes/aged-date.pipe';
 import { CamelspacePipe } from './pipes/camelspace.pipe';
 import { CountdownPipe } from './pipes/countdown.pipe';
@@ -17,7 +16,9 @@ import { ShortDatePipe } from './pipes/short-date.pipe';
 import { ShortTimePipe } from './pipes/short-time.pipe';
 import { UntagPipe } from './pipes/untag.pipe';
 import { DropzoneComponent } from './components/dropzone/dropzone.component';
+import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ButtonsModule } from 'ngx-bootstrap/buttons';
+import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { GameCardComponent } from './components/game-card/game-card.component';
 import { YamlPipe } from './pipes/yaml.pipe';
 import { LoginComponent } from './components/login/login.component';
@@ -29,7 +30,6 @@ import { MessageBoardComponent } from './components/message-board/message-board.
 import { SafeUrlPipe } from './pipes/safe-url.pipe';
 import { ObserveOrderPipe } from './pipes/observe-order.pipe';
 import { MatchesTermPipe } from './pipes/matches-term.pipe';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { UntilPipe } from './pipes/until-date.pipe';
 
 const components = [

--- a/projects/gameboard-ui/src/app/utility/utility.module.ts
+++ b/projects/gameboard-ui/src/app/utility/utility.module.ts
@@ -29,6 +29,7 @@ import { MessageBoardComponent } from './components/message-board/message-board.
 import { SafeUrlPipe } from './pipes/safe-url.pipe';
 import { ObserveOrderPipe } from './pipes/observe-order.pipe';
 import { MatchesTermPipe } from './pipes/matches-term.pipe';
+import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
 const components = [
   ClipspanComponent,
@@ -61,8 +62,9 @@ const components = [
     FormsModule,
     FontAwesomeModule,
     AlertModule,
-    TooltipModule.forRoot(),
-    ButtonsModule
+    TooltipModule,
+    ButtonsModule,
+    BsDropdownModule
   ],
 })
 export class UtilityModule { }

--- a/projects/gameboard-ui/src/app/utility/utility.module.ts
+++ b/projects/gameboard-ui/src/app/utility/utility.module.ts
@@ -30,6 +30,7 @@ import { SafeUrlPipe } from './pipes/safe-url.pipe';
 import { ObserveOrderPipe } from './pipes/observe-order.pipe';
 import { MatchesTermPipe } from './pipes/matches-term.pipe';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
+import { UntilPipe } from './pipes/until-date.pipe';
 
 const components = [
   ClipspanComponent,
@@ -42,6 +43,7 @@ const components = [
   ProfileEditorComponent,
   MessageBoardComponent,
   AgedDatePipe,
+  UntilPipe,
   CamelspacePipe,
   CountdownPipe,
   ShortDatePipe,

--- a/projects/gameboard-ui/src/styles.scss
+++ b/projects/gameboard-ui/src/styles.scss
@@ -17,7 +17,7 @@
 @import "../../../node_modules/bootstrap/scss/forms";
 @import "../../../node_modules/bootstrap/scss/buttons";
 @import "../../../node_modules/bootstrap/scss/transitions";
-// @import "../../../node_modules/bootstrap/scss/dropdown";
+@import "../../../node_modules/bootstrap/scss/dropdown";
 @import "../../../node_modules/bootstrap/scss/button-group";
 @import "../../../node_modules/bootstrap/scss/input-group";
 // @import "../../../node_modules/bootstrap/scss/custom-forms";

--- a/projects/gameboard-ui/src/styles.scss
+++ b/projects/gameboard-ui/src/styles.scss
@@ -121,3 +121,21 @@ app-spinner svg {
 .grayText {
   color: #767676;
 }
+
+// bootstrap tooltip styled to show up on dark theme
+.light-tooltip.bs-tooltip-top .tooltip-arrow::before {
+  border-top-color: white;
+}
+.light-tooltip.bs-tooltip-bottom .tooltip-arrow::before {
+  border-bottom-color: white;
+}
+.light-tooltip.bs-tooltip-right .tooltip-arrow::before {
+  border-right-color: white;
+}
+.light-tooltip.bs-tooltip-left .tooltip-arrow::before {
+  border-left-color: white;
+}
+.light-tooltip .tooltip-inner {
+  background-color: white;
+  color: black;
+}


### PR DESCRIPTION
Corresponding API changes: https://github.com/cmu-sei/Gameboard/pull/39

Changes:
- Admin game editor has datalists of suggestions for each field
- Toggle admin dashboard between table and card view
- Group game cards by month and year for "Upcoming" and "Completed" games on the landing page
- Game card hover metadata with registration and competition relative times
- Basic search-by-term feature for landing page; works the same as search in admin dashboard
- Many minor UI tweaks to formatting and styling
- Short save delay in game editor