### PR TITLE
Made role reqirement consistent with API for Admin Start

### DIFF
--- a/projects/gameboard-ui/src/app/game/player-enroll/player-enroll.component.html
+++ b/projects/gameboard-ui/src/app/game/player-enroll/player-enroll.component.html
@@ -55,7 +55,7 @@
           </div>
         </ng-container>
 
-        <div *ngIf="ctx.user.isDesigner && !ctx.game.registration.isDuring" class="text-center">
+        <div *ngIf="ctx.user.isRegistrar && !ctx.game.registration.isDuring" class="text-center">
           <app-confirm-button btnClass="btn btn-primary btn-lg" (confirm)="enroll(ctx.user.id, ctx.game.id)">
             <fa-icon [icon]="faEdit"></fa-icon>
             <span>Admin Enroll</span>

--- a/projects/gameboard-ui/src/app/game/player-session/player-session.component.html
+++ b/projects/gameboard-ui/src/app/game/player-session/player-session.component.html
@@ -115,7 +115,7 @@
 
       </ng-container>
 
-      <ng-container *ngIf="ctx.user.isDesigner && !ctx.player.session.isDuring">
+      <ng-container *ngIf="ctx.user.isRegistrar && !ctx.player.session.isDuring">
         <div class="text-center my-4">
           <app-confirm-button btnClass="btn btn-lg btn-primary" (confirm)="start(ctx.player)">
             <fa-icon [icon]="faBolt"></fa-icon>


### PR DESCRIPTION
UI-only change.

- Change when Admin Enroll and Admin Start buttons display. Use `isRegistrar` instead of `isDesigner` to be consistent with what the API enforces.
