### PR TITLE
Added card text to placeholder text in game search

### DIFF
--- a/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
+++ b/projects/gameboard-ui/src/app/admin/dashboard/dashboard.component.html
@@ -21,7 +21,7 @@
       <span id="search-label" class="input-group-text">Search</span>
     </div>
     <input id="search-input" type="search" autocomplete="off" class="form-control border-0" [(ngModel)]="search.term" (input)="typing($event)"
-      aria-label="search term" aria-describedby="search-label" placeholder="Enter name, season, track, division, series, sponsor, key, mode, or id">
+      aria-label="search term" aria-describedby="search-label" placeholder="Enter name, season, track, division, series, sponsor, key, mode, card text, or id">
   </div>
 
   <!-- <div class=""> -->


### PR DESCRIPTION
Corresponding API changes: https://github.com/cmu-sei/Gameboard/pull/40

- Add card text to search bar placeholder explanation in admin game dashboard now that card text is searchable