### PR TITLE
Registration enhancements

### DIFF
--- a/projects/gameboard-ui/src/app/api/player.service.ts
+++ b/projects/gameboard-ui/src/app/api/player.service.ts
@@ -93,11 +93,20 @@ export class PlayerService {
     return this.http.get<PlayerCertificate[]>(`${this.url}/certificates`);
   }
 
-  public transform(p: Player): Player {
+  public transform(p: Player, disallowedName: string | null = null): Player {
     p.sponsorLogo = p.sponsor
       ? `${this.config.imagehost}/${p.sponsor}`
       : `${this.config.basehref}assets/sponsor.svg`
     ;
+
+    // If the user has no name status but they changed their name, it's pending approval
+    if (!p.nameStatus && p.approvedName !== p.name) {
+      p.nameStatus = 'pending';
+    }
+    // Otherwise, if the user entered a name and an admin rejected it, but the new name entered is different, it's pending
+    else if (p.nameStatus != 'pending' && disallowedName && disallowedName !== p.name) {
+      p.nameStatus = 'pending';
+    }
 
     p.pendingName = p.approvedName !== p.name
       ? p.name + (!!p.nameStatus ? `...${p.nameStatus}` : '...pending')

--- a/projects/gameboard-ui/src/app/game/player-enroll/player-enroll.component.html
+++ b/projects/gameboard-ui/src/app/game/player-enroll/player-enroll.component.html
@@ -72,11 +72,12 @@
 
         <div *ngIf="ctx.player.isManager" class="form-group mb-0">
 
-          <ng-container *ngIf="!ctx.player.nameStatus && ctx.player.name == ctx.player.approvedName">
+          <!-- Confirmation popup -->
+          <!-- ng-container *ngIf="!ctx.player.nameStatus && ctx.player.name == ctx.player.approvedName">
             <div class="alert alert-success">
                 Your name has been approved.
             </div>
-          </ng-container>
+          </ng-container -->
           <ng-container *ngIf="ctx.player.name !== ctx.player.approvedName">
               <ng-container *ngIf="ctx.player.nameStatus == 'pending' && ctx.player.name != disallowedName">
                   <div class="alert alert-info">

--- a/projects/gameboard-ui/src/app/game/player-enroll/player-enroll.component.html
+++ b/projects/gameboard-ui/src/app/game/player-enroll/player-enroll.component.html
@@ -71,6 +71,27 @@
         *ngIf="!!ctx.player.id && ctx.player.session.isBefore && ctx.game.registration.isDuring">
 
         <div *ngIf="ctx.player.isManager" class="form-group mb-0">
+
+          <ng-container *ngIf="!ctx.player.nameStatus && ctx.player.name == ctx.player.approvedName">
+            <div class="alert alert-success">
+                Your name has been approved.
+            </div>
+          </ng-container>
+          <ng-container *ngIf="ctx.player.name !== ctx.player.approvedName">
+              <ng-container *ngIf="ctx.player.nameStatus == 'pending' && ctx.player.name != disallowedName">
+                  <div class="alert alert-info">
+                      Your name is pending approval from an administrator. Return later or select 'Refresh' to see if it's been approved.
+                  </div>
+              </ng-container>
+              <ng-container *ngIf="ctx.player.nameStatus && ctx.player.nameStatus != 'pending'">
+                  <div class="alert alert-danger">
+                      Your name was rejected by an administrator for the following reason:<br>
+                      <strong>{{ctx.player.nameStatus}}</strong><br>
+                      Please change it and try again.
+                  </div>
+              </ng-container>
+          </ng-container>
+
           <label for="name-input">Set {{ctx.game.maxTeamSize > 1 ? 'Team' : 'Game'}} Display Name</label>
           <div class="input-group mb-0">
             <input id="name-input" type="text" class="form-control" [(ngModel)]="ctx.player.name" maxlength="64" autocomplete="off"

--- a/projects/gameboard-ui/src/app/game/player-enroll/player-enroll.component.html
+++ b/projects/gameboard-ui/src/app/game/player-enroll/player-enroll.component.html
@@ -80,7 +80,7 @@
           <ng-container *ngIf="ctx.player.name !== ctx.player.approvedName">
               <ng-container *ngIf="ctx.player.nameStatus == 'pending' && ctx.player.name != disallowedName">
                   <div class="alert alert-info">
-                      Your name is pending approval from an administrator. Return later or select 'Refresh' to see if it's been approved.
+                      Your name is pending approval from an administrator. Return later or select 'Update' to see if it's been approved.
                   </div>
               </ng-container>
               <ng-container *ngIf="ctx.player.nameStatus && ctx.player.nameStatus != 'pending'">

--- a/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.html
+++ b/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.html
@@ -68,7 +68,7 @@
             If your sponsor isn't represented here, <a [routerLink]="'/support/create'">file a support ticket</a>.
         </div>
 
-        <ng-container *ngIf="ctx.user.sponsor">
+        <ng-container *ngIf="!ctx.user.sponsor">
             <br>
             <div class="alert alert-warning">
                 No sponsoring organization selected. Please select an organization below.

--- a/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.html
+++ b/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.html
@@ -7,11 +7,31 @@
         <a class="btn btn-link" [routerLink]="['/', 'profile', 'certificates']">Certificates</a>
     </div>
 
-    <h4>Set your display name</h4>
+    <h4>1. Set your display name</h4>
 
-    <p>
-        Choose a <em>default</em> name for public display that is suitable for all audiences.
-    </p>
+    <div>
+        Choose a <em>default</em> name for public display that is suitable for all audiences. This name will apply to <em>all new games</em>, however you can customize it during registration.
+    </div>
+    <br>
+    <ng-container *ngIf="!ctx.user.nameStatus && ctx.user.name == ctx.user.approvedName">
+        <div class="alert alert-success">
+            Your name has been approved.
+        </div>
+    </ng-container>
+    <ng-container *ngIf="ctx.user.name !== ctx.user.approvedName">
+        <ng-container *ngIf="ctx.user.nameStatus == 'pending' && ctx.user.name != disallowedName">
+            <div class="alert alert-info">
+                Your name is pending approval from an administrator. Return later or select 'Refresh' to see if it's been approved.
+            </div>
+        </ng-container>
+        <ng-container *ngIf="ctx.user.nameStatus && ctx.user.nameStatus != 'pending'">
+            <div class="alert alert-danger">
+                Your name was rejected by an administrator for the following reason:<br>
+                <strong>{{ctx.user.nameStatus}}</strong><br>
+                Please change it and try again.
+            </div>
+        </ng-container>
+    </ng-container>
     <div class="row">
         <div class="form-group w-25 d-inline-block">
             <label for="nameInput">Requested Display Name</label>
@@ -22,11 +42,11 @@
                 <label for="">Approved Display Name</label>
                 <span class="form-control bg-light text-dark">{{ctx.user.approvedName}}</span>
             </div>
-            <div class="form-group w-25 d-inline-block">
+            <!--div class="form-group w-25 d-inline-block">
                 <label for="">Display Name Status</label>
                 <span class="form-control bg-light text-dark">{{ctx.user.nameStatus}}</span>
-            </div>
-            <div class="form-group w-25 d-inline-block">
+            </div-->
+            <div class="form-group w-25 d-inline-block d-flex align-items-end">
                 <button class="btn btn-secondary" (click)="refresh(ctx.user)">
                     <fa-icon [icon]="faSync"></fa-icon>
                     <span>Refresh</span>
@@ -35,7 +55,21 @@
         </ng-container>
     </div>
 
-    <h4>Select your sponsoring organization</h4>
+    <!-- hr style="border-color:white" -->
+
+    <h4>2. Select your sponsoring organization</h4>
+    
+    <div>
+        To participate in a game, you must select your organization. This organization will display on the leaderboard alongside your name.<br>
+        If your sponsor isn't represented here, <a [routerLink]="'/support/create'">file a support ticket</a>.
+    </div>
+
+    <ng-container *ngIf="!ctx.user.sponsor">
+        <br>
+        <div class="alert alert-danger">
+            No sponsoring organization selected. Please select an organization below.
+        </div>
+    </ng-container>
 
     <ng-container *ngFor="let s of ctx.sponsors">
         <div class="card" [class.active]="ctx.user.sponsor===s.logo" (click)="setSponsor(ctx.user, s)">

--- a/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.html
+++ b/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.html
@@ -65,7 +65,7 @@
         
         <div>
             To participate in a game, you must select your organization. This organization will display on the leaderboard alongside your name.<br>
-            If your sponsor isn't represented here, <a [routerLink]="'/support/create'">file a support ticket</a>.
+            If your sponsor isn't represented here, please <a [routerLink]="'/support/create'">file a support ticket</a>.
         </div>
 
         <ng-container *ngIf="!ctx.user.sponsor">

--- a/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.html
+++ b/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.html
@@ -7,37 +7,40 @@
         <a class="btn btn-link" [routerLink]="['/', 'profile', 'certificates']">Certificates</a>
     </div>
 
-    <h4>1. Set your display name</h4>
+    <div class="w-75 d-inline-block">
+        <h4>1. Set your display name</h4>
 
-    <div>
-        Choose a <em>default</em> name for public display that is suitable for all audiences. This name will apply to <em>all new games</em>, however you can customize it during registration.
-    </div>
-    <br>
-    <ng-container *ngIf="!ctx.user.nameStatus && ctx.user.name == ctx.user.approvedName">
-        <div class="alert alert-success">
-            Your name has been approved.
+        <div>
+            Choose a <em>default</em> name for public display that is suitable for all audiences. This name will apply to <em>all new games</em>, however you can customize it during registration.
         </div>
-    </ng-container>
-    <ng-container *ngIf="ctx.user.name !== ctx.user.approvedName">
-        <ng-container *ngIf="ctx.user.nameStatus == 'pending' && ctx.user.name != disallowedName">
-            <div class="alert alert-info">
-                Your name is pending approval from an administrator. Return later or select 'Refresh' to see if it's been approved.
+        <br>
+        <!-- Confirmation popup -->
+        <!-- ng-container *ngIf="!ctx.user.nameStatus && ctx.user.name == ctx.user.approvedName">
+            <div class="alert alert-success">
+                Your name has been approved.
             </div>
+        </ng-container -->
+        <ng-container *ngIf="ctx.user.name !== ctx.user.approvedName">
+            <ng-container *ngIf="ctx.user.nameStatus == 'pending' && ctx.user.name != disallowedName">
+                <div class="alert alert-info">
+                    Your name is pending approval from an administrator. Return later or select 'Refresh' to see if it's been approved.
+                </div>
+            </ng-container>
+            <ng-container *ngIf="ctx.user.nameStatus && ctx.user.nameStatus != 'pending'">
+                <div class="alert alert-danger">
+                    Your name was rejected by an administrator for the following reason:<br>
+                    <strong>{{ctx.user.nameStatus}}</strong><br>
+                    Please change it and try again.
+                </div>
+            </ng-container>
         </ng-container>
-        <ng-container *ngIf="ctx.user.nameStatus && ctx.user.nameStatus != 'pending'">
-            <div class="alert alert-danger">
-                Your name was rejected by an administrator for the following reason:<br>
-                <strong>{{ctx.user.nameStatus}}</strong><br>
-                Please change it and try again.
-            </div>
-        </ng-container>
-    </ng-container>
+    </div>
     <div class="row">
         <div class="form-group w-25 d-inline-block">
             <label for="nameInput">Requested Display Name</label>
             <input id="nameInput" class="form-control" [(ngModel)]="ctx.user.name" (input)="updating$.next(ctx.user)"  placeholder="display name" maxlength="64">
         </div>
-        <ng-container *ngIf="ctx.user.name !== ctx.user.approvedName">
+        <ng-container>
             <div class="form-group w-25 d-inline-block">
                 <label for="">Approved Display Name</label>
                 <span class="form-control bg-light text-dark">{{ctx.user.approvedName}}</span>
@@ -57,19 +60,22 @@
 
     <!-- hr style="border-color:white" -->
 
-    <h4>2. Select your sponsoring organization</h4>
-    
-    <div>
-        To participate in a game, you must select your organization. This organization will display on the leaderboard alongside your name.<br>
-        If your sponsor isn't represented here, <a [routerLink]="'/support/create'">file a support ticket</a>.
-    </div>
-
-    <ng-container *ngIf="!ctx.user.sponsor">
-        <br>
-        <div class="alert alert-danger">
-            No sponsoring organization selected. Please select an organization below.
+    <div class="w-75 d-inline-block">
+        <h4>2. Select your sponsoring organization</h4>
+        
+        <div>
+            To participate in a game, you must select your organization. This organization will display on the leaderboard alongside your name.<br>
+            If your sponsor isn't represented here, <a [routerLink]="'/support/create'">file a support ticket</a>.
         </div>
-    </ng-container>
+
+        <ng-container *ngIf="ctx.user.sponsor">
+            <br>
+            <div class="alert alert-warning">
+                No sponsoring organization selected. Please select an organization below.
+            </div>
+        </ng-container>
+    </div>
+    <br>
 
     <ng-container *ngFor="let s of ctx.sponsors">
         <div class="card" [class.active]="ctx.user.sponsor===s.logo" (click)="setSponsor(ctx.user, s)">

--- a/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.ts
+++ b/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.ts
@@ -23,6 +23,9 @@ export class ProfileEditorComponent implements OnInit {
 
   faSync = faSyncAlt;
 
+  disallowedName: string | null = null;
+  disallowedReason: string | null = null;
+
   constructor(
     api: ApiUserService,
     private userSvc: UserService,
@@ -36,7 +39,14 @@ export class ProfileEditorComponent implements OnInit {
       this.updating$.pipe(
         debounceTime(500),
         filter(u => !!u.name.trim()),
-        switchMap(u => api.update(u))
+        tap(u => {
+          // If the user's name isn't the disallowed one, mark it as pending
+          if (u.name != this.disallowedName) u.nameStatus = "pending";
+          // Otherwise, if there is a disallowed reason as well, mark it as that reason
+          else if (this.disallowedReason) u.nameStatus = this.disallowedReason;
+          //
+        }),
+        switchMap(u => api.update(u, this.disallowedName))
         // todo handle errors
       )
     ], asyncScheduler).pipe(
@@ -47,7 +57,15 @@ export class ProfileEditorComponent implements OnInit {
       currentUser$,
       sponsorSvc.list('')
     ]).pipe(
-      map(([user, sponsors]) => ({user, sponsors}))
+      map(([user, sponsors]) => ({user, sponsors})),
+      tap((us) => {
+        if (us.user.nameStatus && us.user.nameStatus != 'pending') {
+          if (this.disallowedName == null) {
+            this.disallowedName = us.user.name;
+            this.disallowedReason = us.user.nameStatus;
+          }
+        }
+      })
     );
   }
 

--- a/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.ts
+++ b/projects/gameboard-ui/src/app/utility/components/profile-editor/profile-editor.component.ts
@@ -44,7 +44,6 @@ export class ProfileEditorComponent implements OnInit {
           if (u.name != this.disallowedName) u.nameStatus = "pending";
           // Otherwise, if there is a disallowed reason as well, mark it as that reason
           else if (this.disallowedReason) u.nameStatus = this.disallowedReason;
-          //
         }),
         switchMap(u => api.update(u, this.disallowedName))
         // todo handle errors


### PR DESCRIPTION
Registration feedback now provided in greater detail and clarity across individual player and team registration.
- Individual registration is now numbered to provide a clearer sequence flow and list of requirements.
- Individual registration help text has been expanded for greater detail.
- Individual registration now shows a warning if a sponsor is not chosen.
- Individual and team registration now displays different popup statuses depending on name statuses. If the player/team name is:
  - **Allowed**: nothing different displays.
  - **Pending approval**: a blue popup appears with info about the approval process.
  - **Disallowed**: a red popup appears with the reason why the name was rejected.
- Width adjusted for registration text and popups to be 75% of the page length