### PR TITLE
Feedback enhancements - more feedback options

### DIFF
--- a/projects/gameboard-ui/src/app/admin/feedback-report/feedback-report.component.html
+++ b/projects/gameboard-ui/src/app/admin/feedback-report/feedback-report.component.html
@@ -77,6 +77,8 @@
           <div class="col-2">{{feedbackStats.configuredCount}} <span class="m-0 p-0 text-muted">questions</span></div>
           <div class="col-2">{{feedbackStats.likertCount}} <span class="m-0 p-0 text-muted">likert</span></div>
           <div class="col-2">{{feedbackStats.textCount}} <span class="m-0 p-0 text-muted">text</span></div>
+          <div class="col-2">{{feedbackStats.selectOneCount}} <span class="m-0 p-0 text-muted">selectOne</span></div>
+          <div class="col-2">{{feedbackStats.selectAllThatApplyCount}} <span class="m-0 p-0 text-muted">selectAllThatApply</span></div>
           <div class="col-2">{{feedbackStats.requiredCount}} <span class="m-0 p-0 text-muted">required</span></div>
         </div>
         <div class="row border-top p-2 text-left">

--- a/projects/gameboard-ui/src/app/admin/feedback-report/feedback-report.component.html
+++ b/projects/gameboard-ui/src/app/admin/feedback-report/feedback-report.component.html
@@ -78,7 +78,7 @@
           <div class="col-2">{{feedbackStats.likertCount}} <span class="m-0 p-0 text-muted">likert</span></div>
           <div class="col-2">{{feedbackStats.textCount}} <span class="m-0 p-0 text-muted">text</span></div>
           <div class="col-2">{{feedbackStats.selectOneCount}} <span class="m-0 p-0 text-muted">selectOne</span></div>
-          <div class="col-2">{{feedbackStats.selectAllThatApplyCount}} <span class="m-0 p-0 text-muted">selectAllThatApply</span></div>
+          <div class="col-2">{{feedbackStats.selectManyCount}} <span class="m-0 p-0 text-muted">selectMany</span></div>
           <div class="col-2">{{feedbackStats.requiredCount}} <span class="m-0 p-0 text-muted">required</span></div>
         </div>
         <div class="row border-top p-2 text-left">

--- a/projects/gameboard-ui/src/app/api/feedback-models.ts
+++ b/projects/gameboard-ui/src/app/api/feedback-models.ts
@@ -51,6 +51,7 @@ export interface FeedbackQuestion {
   maxLabel?: string;
   options?: string[];
   display?: string;
+  specify?: QuestionSpecify;
 }
 
 export interface FeedbackTemplate {
@@ -77,6 +78,11 @@ export interface QuestionStats {
   count?: string; 
   lowest?: string; 
   highest?: string; 
+}
+
+export interface QuestionSpecify {
+  key?: string,
+  prompt?: string
 }
 
 export interface FeedbackStats {

--- a/projects/gameboard-ui/src/app/api/feedback-models.ts
+++ b/projects/gameboard-ui/src/app/api/feedback-models.ts
@@ -64,7 +64,7 @@ export enum QuestionType {
   likert = 'likert',
   text = 'text',
   selectOne = 'selectOne',
-  selectAllThatApply = 'selectAllThatApply'
+  selectMany = 'selectMany'
 }
 
 export interface QuestionStats {
@@ -92,7 +92,7 @@ export interface FeedbackStats {
   likertCount: number;
   textCount: number;
   selectOneCount: number;
-  selectAllThatApplyCount: number;
+  selectManyCount: number;
   requiredCount: number;
   responsesCount: number;
   maxResponseCount: number;

--- a/projects/gameboard-ui/src/app/api/feedback-models.ts
+++ b/projects/gameboard-ui/src/app/api/feedback-models.ts
@@ -49,6 +49,8 @@ export interface FeedbackQuestion {
   max?: number;
   minLabel?: string;
   maxLabel?: string;
+  options?: string[];
+  display?: string;
 }
 
 export interface FeedbackTemplate {
@@ -59,7 +61,9 @@ export interface FeedbackTemplate {
 
 export enum QuestionType {
   likert = 'likert',
-  text = 'text'
+  text = 'text',
+  selectOne = 'selectOne',
+  selectAllThatApply = 'selectAllThatApply'
 }
 
 export interface QuestionStats {
@@ -81,6 +85,8 @@ export interface FeedbackStats {
   configuredCount: number;
   likertCount: number;
   textCount: number;
+  selectOneCount: number;
+  selectAllThatApplyCount: number;
   requiredCount: number;
   responsesCount: number;
   maxResponseCount: number;

--- a/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.html
+++ b/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.html
@@ -60,7 +60,7 @@
       </div>
     </ng-container>
     <!-- Select all that apply -->
-    <ng-container *ngIf="q.type == 'selectAllThatApply'">
+    <ng-container *ngIf="q.type == 'selectMany'">
       <div id={{q.id}}>
         <ng-container *ngFor="let option of q.options">
           <div class="form-check">

--- a/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.html
+++ b/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.html
@@ -42,17 +42,19 @@
     <ng-container *ngIf="q.type == 'selectOne'">
       <!-- Dropdown -->
       <div *ngIf="q.display == 'dropdown'" id={{q.id}}>
-        <select id="dropdown-{{q.id}}" class="btn btn-secondary">
-          <option *ngFor="let option of q.options" class="dropdown-item px-3" [(ngModel)]="q.answer" [disabled]="feedbackForm.submitted!" ngDefaultControl [id]="option" [name]="option" [value]="option">{{option}}</option>
-          <option ngDefaultControl id="{{q.id}}-Unspecified" name="(Unspecified)" value="(Unspecified)" class="dropdown-item" selected>(Unspecified)</option>
+        <select id="dropdown-{{q.id}}" class="btn btn-secondary" [(ngModel)]="q.answer" [name]="q.id">
+          <option ngDefaultControl [value]="null" class="dropdown-item" selected>---</option>
+          <option *ngFor="let option of q.options" class="dropdown-item px-3" [disabled]="feedbackForm.submitted!" ngDefaultControl [value]="option" [selected]="q.answer == option">{{option}}</option>
         </select>
       </div>
       <!-- Radio buttons -->
       <div *ngIf="q.display != 'dropdown'" id={{q.id}}>
         <ng-container *ngFor="let option of q.options">
           <div class="form-check">
-            <input class="form-check-input" type="radio" [(ngModel)]="q.answer" [disabled]="feedbackForm.submitted!" [id]="option" [name]="option" [value]="option">
-            <label class="form-check-label" for="{{option}}">{{option}}</label>
+            <input class="form-check-input" type="radio" (change)="modifyMultipleAnswer(q, option, $event, true)" [checked]="q.answer && q.answer!.indexOf(option) > -1" [disabled]="feedbackForm.submitted!" id="check-{{q.id}}-{{option}}" [name]="q.id" [value]="option">
+            <label class="form-check-label" for="{{option}}">{{option}}{{q.specify && q.specify.key == option ? ": " + (q.specify.prompt ? q.specify.prompt : "") : "" }}</label>
+            <br>
+            <textarea *ngIf="q.specify && q.specify.key == option" rows="1" type="text" [disabled]="feedbackForm.submitted!" style="white-space: pre; overflow-wrap: normal; overflow-x: scroll; resize: none" (change)="modifySpecifiedAnswer(q, option, $event)" id="input-{{q.id}}-{{option}}"></textarea>
           </div>
         </ng-container>
       </div>
@@ -62,8 +64,10 @@
       <div id={{q.id}}>
         <ng-container *ngFor="let option of q.options">
           <div class="form-check">
-            <input class="form-check-input" type="checkbox" (change)="modifyMultipleAnswer(q, option, $event)" [checked]="q.answer && q.answer!.indexOf(option) > -1" [disabled]="feedbackForm.submitted!" [id]="option" [name]="option" [value]="option">
-            <label class="form-check-label" for="{{option}}">{{option}}</label>
+            <input class="form-check-input" type="checkbox" (change)="modifyMultipleAnswer(q, option, $event)" [checked]="q.answer && q.answer!.indexOf(option) > -1" [disabled]="feedbackForm.submitted!" id="check-{{q.id}}-{{option}}" [name]="option" [value]="option">
+            <label class="form-check-label" for="{{option}}">{{option}}{{q.specify && q.specify.key == option ? ": " + (q.specify.prompt ? q.specify.prompt : "") : "" }}</label>
+            <br>
+            <textarea *ngIf="q.specify && q.specify.key == option" rows="1" type="text" [disabled]="feedbackForm.submitted!" style="white-space: pre; overflow-wrap: normal; overflow-x: scroll; resize: none" (change)="modifySpecifiedAnswer(q, option, $event)" id="input-{{q.id}}-{{option}}"></textarea>
           </div>
         </ng-container>
       </div>

--- a/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.html
+++ b/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.html
@@ -43,7 +43,7 @@
       <!-- Dropdown -->
       <div *ngIf="q.display == 'dropdown'" id={{q.id}}>
         <select id="dropdown-{{q.id}}" class="btn btn-secondary" [(ngModel)]="q.answer" [name]="q.id">
-          <option ngDefaultControl [value]="null" class="dropdown-item" selected>---</option>
+          <option ngDefaultControl [value]="''" class="dropdown-item" selected>---</option>
           <option *ngFor="let option of q.options" class="dropdown-item px-3" [disabled]="feedbackForm.submitted!" ngDefaultControl [value]="option" [selected]="q.answer == option">{{option}}</option>
         </select>
       </div>

--- a/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.html
+++ b/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.html
@@ -20,13 +20,15 @@
       {{i+1}}. {{q.prompt}}
       <span *ngIf="q.required" class="required">*</span>
     </label>
+    <!-- Text -->
     <ng-container *ngIf="q.type == 'text'">
-      <textarea rows="3" type="text" class="form-control" id={{q.id}} name={{q.id}}
-      [(ngModel)]="q.answer" [disabled]="feedbackForm.submitted!" maxlength={{characterLimit}}></textarea>
+      <textarea rows="1" type="text" class="form-control" id={{q.id}} name={{q.id}}
+      [(ngModel)]="q.answer" [disabled]="feedbackForm.submitted!" maxlength={{characterLimit}} style="white-space: pre; overflow-wrap: normal; overflow-x: scroll; resize: none"></textarea>
       <small class="d-flex justify-content-end" [class]="q.answer?.length == characterLimit ? 'text-warning' : 'text-muted'">
         {{characterLimit - (q.answer?.length ?? 0)}}
       </small>
     </ng-container>
+    <!-- Likert -->
     <div *ngIf="q.type == 'likert'">
       <small class="pr-2 text-dark">{{q.minLabel}}</small>
       <div id={{q.id}} class="btn-group" btnRadioGroup name={{q.id}} tabindex="0" [(ngModel)]="q.answer"
@@ -36,6 +38,36 @@
       </div>
       <small class="pl-2 text-dark">{{q.maxLabel}}</small>
     </div>
+    <!-- Select one -->
+    <ng-container *ngIf="q.type == 'selectOne'">
+      <!-- Dropdown -->
+      <div *ngIf="q.display == 'dropdown'" id={{q.id}}>
+        <select id="dropdown-{{q.id}}" class="btn btn-secondary">
+          <option *ngFor="let option of q.options" class="dropdown-item px-3" [(ngModel)]="q.answer" [disabled]="feedbackForm.submitted!" ngDefaultControl [id]="option" [name]="option" [value]="option">{{option}}</option>
+          <option ngDefaultControl id="{{q.id}}-Unspecified" name="(Unspecified)" value="(Unspecified)" class="dropdown-item" selected>(Unspecified)</option>
+        </select>
+      </div>
+      <!-- Radio buttons -->
+      <div *ngIf="q.display != 'dropdown'" id={{q.id}}>
+        <ng-container *ngFor="let option of q.options">
+          <div class="form-check">
+            <input class="form-check-input" type="radio" [(ngModel)]="q.answer" [disabled]="feedbackForm.submitted!" [id]="option" [name]="option" [value]="option">
+            <label class="form-check-label" for="{{option}}">{{option}}</label>
+          </div>
+        </ng-container>
+      </div>
+    </ng-container>
+    <!-- Select all that apply -->
+    <ng-container *ngIf="q.type == 'selectAllThatApply'">
+      <div id={{q.id}}>
+        <ng-container *ngFor="let option of q.options">
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" (change)="modifyMultipleAnswer(q, option, $event)" [checked]="q.answer && q.answer!.indexOf(option) > -1" [disabled]="feedbackForm.submitted!" [id]="option" [name]="option" [value]="option">
+            <label class="form-check-label" for="{{option}}">{{option}}</label>
+          </div>
+        </ng-container>
+      </div>
+    </ng-container>
   </div>
 
   <app-confirm-button btnClass="btn btn-sm btn-secondary" (confirm)="submit()" [disabled]="feedbackForm.submitted! || !feedbackForm?.questions?.length">

--- a/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.ts
+++ b/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.ts
@@ -211,16 +211,41 @@ export class FeedbackFormComponent implements OnInit, AfterViewInit {
   }
 
   // Used to change the answer for a question as multiple choices are selected
-  modifyMultipleAnswer(question: FeedbackQuestion, answerChunk: string, checkedEvent: any) {
+  modifyMultipleAnswer(question: FeedbackQuestion, answerChunk: string, checkedEvent: any, isRadio: boolean = false) {
     // If the answer is undefined, set it to be an empty string
     if (!question.answer) question.answer = "";
 
-    // Otherwise, combine it with other answers or remove it from the string
-    if (checkedEvent.target.checked) question.answer += "," + answerChunk;
-    else question.answer = `,${question.answer}`.split(`,${answerChunk}`).join("");
+    // If we're asking for specific information, we have to add on the info entered in the specific info box by looking up its ID
+    let addition: string = ""
+    if (question.specify && question.specify.key == answerChunk) addition = " (" + (<HTMLInputElement>document.getElementById(`input-${question.id}-${answerChunk}`)).value + ")";
+
+    // If this is a radio button, we can just set the answer
+    if (isRadio) {
+      question.answer = answerChunk + addition;
+    }
+    else {
+      // Otherwise, combine it with other answers or remove it from the string
+      if (checkedEvent.target.checked) question.answer += "," + answerChunk + addition;
+      else question.answer = `,${question.answer}`.split(`,${answerChunk + addition}`).join("");
+
+      // If we lead with a comma, remove the comma
+      if (question.answer?.charAt(0) == ",") question.answer = question.answer?.substring(1, question.answer?.length);
+    }
+  }
+
+  // Used to change an answer when the user should enter specific information (like "Other")
+  modifySpecifiedAnswer(question: FeedbackQuestion, answerChunk: string, textChangedEvent: any) {
+    // If the text box is checked and this question has specific info, we can retrieve the box's info and add that onto the answer
+    if ((<HTMLInputElement>document.getElementById(`check-${question.id}-${answerChunk}`)).checked) {
+      if (question.specify && question.specify.key == answerChunk && question.answer) {
+        // Split the string by the option given and whatever characters come after its first parentheses and right before its end parentheses
+        question.answer = question.answer.split(new RegExp(`,?${answerChunk} \\(.*?\\),?`)).join("");
+        // Then add this new answer onto the end
+        question.answer += `,${answerChunk} (${textChangedEvent.target.value})`;
+      }
+    }
 
     // If we lead with a comma, remove the comma
     if (question.answer?.charAt(0) == ",") question.answer = question.answer?.substring(1, question.answer?.length);
   }
-
 }

--- a/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.ts
+++ b/projects/gameboard-ui/src/app/game/feedback-form/feedback-form.component.ts
@@ -210,4 +210,17 @@ export class FeedbackFormComponent implements OnInit, AfterViewInit {
     return Array.from(new Array(max), (x, i) => i + min);
   }
 
+  // Used to change the answer for a question as multiple choices are selected
+  modifyMultipleAnswer(question: FeedbackQuestion, answerChunk: string, checkedEvent: any) {
+    // If the answer is undefined, set it to be an empty string
+    if (!question.answer) question.answer = "";
+
+    // Otherwise, combine it with other answers or remove it from the string
+    if (checkedEvent.target.checked) question.answer += "," + answerChunk;
+    else question.answer = `,${question.answer}`.split(`,${answerChunk}`).join("");
+
+    // If we lead with a comma, remove the comma
+    if (question.answer?.charAt(0) == ",") question.answer = question.answer?.substring(1, question.answer?.length);
+  }
+
 }

--- a/projects/gameboard-ui/src/app/game/game.module.ts
+++ b/projects/gameboard-ui/src/app/game/game.module.ts
@@ -6,7 +6,7 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { UtilityModule } from '../utility/utility.module';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { PlayerEnlistComponent } from './player-enlist/player-enlist.component';
 import { AuthGuard } from '../utility/auth.guard';
 import { PlayerEnrollComponent } from './player-enroll/player-enroll.component';
@@ -25,6 +25,7 @@ import { PlayerPresenceComponent } from './player-presence/player-presence.compo
 import { FeedbackFormComponent } from './feedback-form/feedback-form.component';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { CertificateComponent } from './certificate/certificate.component';
+import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
 
 @NgModule({
@@ -48,6 +49,7 @@ import { CertificateComponent } from './certificate/certificate.component';
   imports: [
     CommonModule,
     FormsModule,
+    ReactiveFormsModule,
     RouterModule.forChild([
       { path: 'teamup/:code', canActivate: [AuthGuard], component: PlayerEnlistComponent },
       { path: 'board/:id', canActivate: [AuthGuard], component: GameboardPageComponent },
@@ -60,7 +62,8 @@ import { CertificateComponent } from './certificate/certificate.component';
     AlertModule,
     MarkdownModule,
     ButtonsModule,
-    ModalModule
+    ModalModule,
+    BsDropdownModule
   ]
 })
 export class GameModule { }


### PR DESCRIPTION
Backend part of the feedback expansion. Allows questions more flexibility in a few ways:
- Questions can now be single-select multiple choice by using `selectOne` as the question type in the feedback yaml file
  - Can be turned into a dropdown by adding `display: dropdown` under the question; otherwise uses radio buttons
- Questions can now be multi-select multiple choice by using `selectMany` as the question type in the feedback yaml file
- Text box can be added to a single-select or multi-select question by adding `specify` under the question, then providing a `key` and a `prompt`
  - `key` determines what answer option in a question has the text box (maximum one text box is allowed per question)
  - `prompt` is the guidance text to help a user give an answer in the text box (can also be left empty)

Example of a single-select dropdown:
```yaml
- id: q1
  prompt: Best captain?
  type: selectOne
  display: dropdown
  options:
    - Kirk
    - Picard
    - Sisko
    - Janeway
    - Archer
```

Example of a multi-select with a text box on the "Other" option:
```yaml
- id: q2
  prompt: What board games do you like?
  type: selectMany
  options:
    - Monopoly
    - Sorry
    - Clue
    - Mouse Trap
    - Settlers of Catan
    - Other
  specify:
    key: Other
    prompt: Please enter a board game for 2+ players ages 8 and up.
```