### PR TITLE
Improvements to support tickets

### DIFF
--- a/projects/gameboard-ui/src/app/admin/support-report/support-report.component.html
+++ b/projects/gameboard-ui/src/app/admin/support-report/support-report.component.html
@@ -28,6 +28,18 @@
   </div>
 </form>
 
+<br>
+
+<div class="container table-dark border mb-4">
+  <div class="row">
+    <div class="col-2 p-2 font-weight-bold">
+      <div>
+        <button class="btn btn-outline-info btn-sm mx-1" (click)="downloadTicketDetailReport()">Export Ticket Detail Report to CSV</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <div class="container">
   <div class="row">
     <div class="col-10 p-2">

--- a/projects/gameboard-ui/src/app/admin/support-report/support-report.component.html
+++ b/projects/gameboard-ui/src/app/admin/support-report/support-report.component.html
@@ -32,9 +32,24 @@
 
 <div class="container table-dark border mb-4">
   <div class="row">
-    <div class="col-2 p-2 font-weight-bold">
+    <div class="col-3 p-2 font-weight-bold">
       <div>
         <button class="btn btn-outline-info btn-sm mx-1" (click)="downloadTicketDetailReport()">Export Ticket Detail Report to CSV</button>
+      </div>
+    </div>
+    <div class="col-3 p-2 font-weight-bold">
+      <div>
+        <button class="btn btn-outline-info btn-sm mx-1" (click)="downloadTicketDayStatsReport()">Export Ticket Day Stats Report to CSV</button>
+      </div>
+    </div>
+    <div class="col-3 p-2 font-weight-bold">
+      <div>
+        <button class="btn btn-outline-info btn-sm mx-1" (click)="downloadTicketLabelStatsReport()">Export Ticket Label Stats Report to CSV</button>
+      </div>
+    </div>
+    <div class="col-3 p-2 font-weight-bold">
+      <div>
+        <button class="btn btn-outline-info btn-sm mx-1" (click)="downloadTicketChallengeStatsReport()">Export Ticket Challenge Stats Report to CSV</button>
       </div>
     </div>
   </div>

--- a/projects/gameboard-ui/src/app/admin/support-report/support-report.component.ts
+++ b/projects/gameboard-ui/src/app/admin/support-report/support-report.component.ts
@@ -34,7 +34,7 @@ export class SupportReportComponent implements OnInit {
 
   constructor(
     private gameService: GameService,
-    private reportService: ReportService,
+    private api: ReportService,
   ) { 
 
     this.gameService.list({}).subscribe(
@@ -44,13 +44,13 @@ export class SupportReportComponent implements OnInit {
     );
 
     this.dayStats$ = this.refresh$.pipe(
-      switchMap(() => this.reportService.supportDays(this.search))
+      switchMap(() => this.api.supportDays(this.search))
     )
     this.labelStats$ = this.refresh$.pipe(
-      switchMap(() => this.reportService.supportLabels(this.search))
+      switchMap(() => this.api.supportLabels(this.search))
     )
     this.challengeStats$ = this.refresh$.pipe(
-      switchMap(() => this.reportService.supportChallenges(this.search))
+      switchMap(() => this.api.supportChallenges(this.search))
     )
   
   }
@@ -74,6 +74,10 @@ export class SupportReportComponent implements OnInit {
     if (this.currentGame)
       this.search.gameId = this.currentGame.id;
     this.refresh$.next(true);
+  }
+
+  downloadTicketDetailReport() {
+    this.api.exportTicketDetails();
   }
 
 }

--- a/projects/gameboard-ui/src/app/admin/support-report/support-report.component.ts
+++ b/projects/gameboard-ui/src/app/admin/support-report/support-report.component.ts
@@ -77,7 +77,18 @@ export class SupportReportComponent implements OnInit {
   }
 
   downloadTicketDetailReport() {
-    this.api.exportTicketDetails();
+    this.api.exportTicketDetails(this.search);
   }
 
+  downloadTicketDayStatsReport() {
+    this.api.exportTicketDayStats(this.search);
+  }
+
+  downloadTicketLabelStatsReport() {
+    this.api.exportTicketLabelStats(this.search);
+  }
+
+  downloadTicketChallengeStatsReport() {
+    this.api.exportTicketChallengeStats(this.search);
+  }
 }

--- a/projects/gameboard-ui/src/app/api/report-models.ts
+++ b/projects/gameboard-ui/src/app/api/report-models.ts
@@ -83,6 +83,28 @@ export interface Part {
   weight: number;
 }
 
+export interface TicketDetailReport {
+  key: string;
+  timestamp: Date;
+  details: TicketDetail[];
+}
+
+export interface TicketDetail {
+  key: number;
+  summary: string;
+  description: string;
+  challenge: string;
+  gameSession: string;
+  team: string;
+  assignee: string;
+  requester: string;
+  creator: string;
+  created: Date;
+  lastUpdated: Date;
+  label: string;
+  status: string;
+}
+
 export interface ParticipationReport {
   key: string;
   timestamp: Date;

--- a/projects/gameboard-ui/src/app/api/report.service.ts
+++ b/projects/gameboard-ui/src/app/api/report.service.ts
@@ -116,6 +116,7 @@ export class ReportService {
     return this.http.get<FeedbackStats>(`${this.url}/report/feedbackstats/`, { params: params });
   }
 
+  //#region Support Reports
   public supportDays(params: any): Observable<any> {
     return this.http.get<any>(`${this.url}/report/supportdaystats/`, { params: params });
   }
@@ -127,6 +128,17 @@ export class ReportService {
   public supportChallenges(params: any): Observable<any> {
     return this.http.get<any>(`${this.url}/report/supportchallengestats/`, { params: params });
   }
+  //#endregion
+
+  //#region Support Report Exports
+  public exportTicketDetails(): void {
+    this.http.get(`${this.url}/report/exportticketdetails/`, { responseType: 'arraybuffer' })
+      .subscribe(response => {
+        const name: string = `ticket-details-report-` + this.timestamp() + '.csv';
+        this.downloadFile(response, name, 'application/ms-excel');
+      });
+  }
+  //#endregion
 
   public participationReport(participationItem: string): Observable<any> {
     return this.http.get<ParticipationReport>(`${this.url}/report/game${participationItem}stats`);

--- a/projects/gameboard-ui/src/app/api/report.service.ts
+++ b/projects/gameboard-ui/src/app/api/report.service.ts
@@ -131,10 +131,34 @@ export class ReportService {
   //#endregion
 
   //#region Support Report Exports
-  public exportTicketDetails(): void {
-    this.http.get(`${this.url}/report/exportticketdetails/`, { responseType: 'arraybuffer' })
+  public exportTicketDetails(params: any): void {
+    this.http.get(`${this.url}/report/exportticketdetails/`, { responseType: 'arraybuffer', params: params })
       .subscribe(response => {
         const name: string = `ticket-details-report-` + this.timestamp() + '.csv';
+        this.downloadFile(response, name, 'application/ms-excel');
+      });
+  }
+
+  public exportTicketDayStats(params: any): void {
+    this.http.get(`${this.url}/report/exportticketdaystats/`, { responseType: 'arraybuffer', params: params })
+      .subscribe(response => {
+        const name: string = `ticket-day-stats-report-` + this.timestamp() + '.csv';
+        this.downloadFile(response, name, 'application/ms-excel');
+      });
+  }
+
+  public exportTicketLabelStats(params: any): void {
+    this.http.get(`${this.url}/report/exportticketlabelstats/`, { responseType: 'arraybuffer', params: params })
+      .subscribe(response => {
+        const name: string = `ticket-label-stats-report-` + this.timestamp() + '.csv';
+        this.downloadFile(response, name, 'application/ms-excel');
+      });
+  }
+
+  public exportTicketChallengeStats(params: any): void {
+    this.http.get(`${this.url}/report/exportticketchallengestats/`, { responseType: 'arraybuffer', params: params })
+      .subscribe(response => {
+        const name: string = `ticket-challenge-stats-report-` + this.timestamp() + '.csv';
         this.downloadFile(response, name, 'application/ms-excel');
       });
   }

--- a/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.html
+++ b/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.html
@@ -71,7 +71,7 @@
               <ng-container *ngFor="let file of ctx.ticket.attachmentFiles; let i = index;">
                 <div class="attachment m-2" (click)="enlarge(ctx.ticket.attachmentFiles, i, attachmentObjectUrls)">
                   <img *ngIf="!!file.showPreview" id="attachment-{{i}}" class="rounded">
-                  <div *ngIf="!file.showPreview" class="p-2 rounded no-preview text-center d-flex flex-column rounded border border-dark">
+                  <div *ngIf="!file.showPreview" id="attachment-{{i}}" class="p-2 rounded no-preview text-center d-flex flex-column rounded border border-dark">
                     <fa-icon class="mt-0 mb-auto no-preview-icon text-dark" [icon]="faFileAlt" size="lg"></fa-icon>
                     <p class="mb-0 mt-auto no-preview-text text-break text-white">{{file.filename | slice:0:26}}</p>
                   </div>
@@ -139,7 +139,7 @@
                   <ng-container *ngFor="let file of activity.attachmentFiles; let j = index;">
                     <div class="attachment m-2" (click)="enlarge(activity.attachmentFiles, j, commentAttachmentMap.get(activity.id))">
                       <img *ngIf="!!file.showPreview" id="comment-attachment-{{activity.id}}-{{j}}" class="rounded">
-                      <div *ngIf="!file.showPreview" class="p-2 rounded no-preview text-center d-flex flex-column rounded border border-dark">
+                      <div *ngIf="!file.showPreview" id="comment-attachment-{{activity.id}}-{{j}}" class="p-2 rounded no-preview text-center d-flex flex-column rounded border border-dark">
                         <fa-icon class="mt-0 mb-auto no-preview-icon text-dark" [icon]="faFileAlt" size="lg"></fa-icon>
                         <p class="mb-0 mt-auto no-preview-text text-break text-white">{{file.filename | slice:0:26}}</p>
                       </div>

--- a/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.ts
+++ b/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.ts
@@ -173,8 +173,8 @@ export class TicketDetailsComponent implements OnInit, AfterViewInit, OnDestroy 
         let url: string = URL.createObjectURL(a.body);
         img.setAttribute("src", url);
         // Set the appropriate storage object based on whether this is being called on a comment or not
-        if (activity) this.commentAttachmentMap.get(activity.id)![imgId] = this.sanitizer.bypassSecurityTrustUrl(url);
-        else this.attachmentObjectUrls[imgId] = this.sanitizer.bypassSecurityTrustUrl(url);
+        if (activity) this.commentAttachmentMap.get(activity.id)![imgId] = this.sanitizer.bypassSecurityTrustResourceUrl(url);
+        else this.attachmentObjectUrls[imgId] = this.sanitizer.bypassSecurityTrustResourceUrl(url);
       }, async (error) => {
         // In case of an error, print it
         console.log("Error encountered while retrieving image.");
@@ -238,6 +238,7 @@ export class TicketDetailsComponent implements OnInit, AfterViewInit, OnDestroy 
       extension: ext,
       // fullPath: this.sanitizer.bypassSecurityTrustResourceUrl(fullPath),
       fullPath: fullPath,
+      // This should be composed of images only
       showPreview: !!ext.toLowerCase().match(/(png|jpeg|jpg|gif|webp|svg)/)
     };
   }

--- a/projects/gameboard-ui/src/app/support/ticket-list/ticket-list.component.html
+++ b/projects/gameboard-ui/src/app/support/ticket-list/ticket-list.component.html
@@ -2,9 +2,15 @@
 
   <div class="d-flex justify-content-between mb-2">
     <h3 class="m-0 p-0 align-self-center">{{ctx.canManage ? 'Manage Tickets' : 'My Tickets'}}</h3>
-    <a class="btn btn-outline-info" [routerLink]="['../create']">
-      <span>Create Ticket</span>
-    </a>
+    <div class="align-self-right">
+      <button class="btn btn-outline-info p-2" (click)="downloadTicketDetailReport()" [disabled]="!ctx.canManage">
+        <fa-icon [icon]="faFileDownload"></fa-icon>
+        <span>Export to CSV</span>
+      </button>
+      <a class="btn btn-outline-info p-2" [routerLink]="['../create']">
+        <span>Create Ticket</span>
+      </a>
+    </div>
   </div>
   <div class="row mb-2">
     <div class="d-flex" [class]="ctx.canManage ? 'col-4' : 'col-2'">

--- a/projects/gameboard-ui/src/app/support/ticket-list/ticket-list.component.html
+++ b/projects/gameboard-ui/src/app/support/ticket-list/ticket-list.component.html
@@ -2,29 +2,27 @@
 
   <div class="d-flex justify-content-between mb-2">
     <h3 class="m-0 p-0 align-self-center">{{ctx.canManage ? 'Manage Tickets' : 'My Tickets'}}</h3>
-    <div class="align-self-right">
-      <button class="btn btn-outline-info p-2" (click)="downloadTicketDetailReport()" [disabled]="!ctx.canManage">
-        <fa-icon [icon]="faFileDownload"></fa-icon>
-        <span>Export to CSV</span>
-      </button>
-      <a class="btn btn-outline-info p-2" [routerLink]="['../create']">
-        <span>Create Ticket</span>
-      </a>
-    </div>
+    <a class="btn btn-outline-info" [routerLink]="['../create']">
+      <span>Create Ticket</span>
+    </a>
   </div>
   <div class="row mb-2">
-    <div class="d-flex" [class]="ctx.canManage ? 'col-4' : 'col-2'">
-      <div class="input-group input-group-sm mr-2">
+    <div class="d-flex" [class]="ctx.canManage ? 'col-7' : 'col-2'">
+      <div class="input-group input-group-sm mr-2 w-25">
         <select class="form-control" [(ngModel)]="statusFilter" (change)="this.refresh$.next(true)">
           <option *ngFor="let option of ['Any Status', 'Open', 'In Progress', 'Closed', 'Not Closed']" [value]="option">
             {{option}}</option>
         </select>
       </div>
-      <div *ngIf="ctx.canManage" class="input-group input-group-sm ml-2">
+      <div *ngIf="ctx.canManage" class="input-group input-group-sm ml-2 w-25">
         <select class="form-control" [(ngModel)]="assignFilter" (change)="this.refresh$.next(true)">
           <option *ngFor="let option of ['Any', 'Assigned to me', 'Unassigned']" [value]="option">{{option}}</option>
         </select>
       </div>
+      <button *ngIf="ctx.canManage" class="btn btn-outline-info btn-sm mx-1 mr-2" (click)="downloadTicketDetailReport()" [disabled]="!ctx.canManage">
+        <fa-icon [icon]="faFileDownload"></fa-icon>
+        <span>csv</span>
+      </button>
     </div>
     <div class="input-group input-group-sm col-5 ml-auto">
       <div class="input-group-prepend">

--- a/projects/gameboard-ui/src/app/support/ticket-list/ticket-list.component.ts
+++ b/projects/gameboard-ui/src/app/support/ticket-list/ticket-list.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { faCaretDown, faCaretUp, faCaretLeft, faCaretRight, faComments, faPaperclip, faSearch, faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
+import { faCaretDown, faCaretUp, faCaretLeft, faCaretRight, faComments, faPaperclip, faSearch, faExclamationCircle, faFileDownload } from '@fortawesome/free-solid-svg-icons';
 import { BehaviorSubject, Observable, timer, combineLatest, Subscription } from 'rxjs';
 import { debounceTime, switchMap, map, tap } from 'rxjs/operators';
+import { ReportService } from '../../api/report.service';
 import { TicketNotification, TicketSummary } from '../../api/support-models';
 import { SupportService } from '../../api/support.service';
 import { ConfigService } from '../../utility/config.service';
@@ -39,11 +40,13 @@ export class TicketListComponent implements OnInit, OnDestroy {
   faCaretRight = faCaretRight;
   faCaretLeft =faCaretLeft;
   faNote = faExclamationCircle;
+  faFileDownload = faFileDownload;
 
   constructor(
     private api: SupportService,
     private local: LocalUserService,
     private config: ConfigService,
+    private reportApi: ReportService,
     hub: NotificationService
   ) {
 
@@ -159,4 +162,9 @@ export class TicketListComponent implements OnInit, OnDestroy {
     this.refresh$.next(true);
     this.advanceRefresh$.next(true);
   }
+
+  downloadTicketDetailReport() {
+    this.reportApi.exportTicketDetails();
+  }
+
 }

--- a/projects/gameboard-ui/src/app/support/ticket-list/ticket-list.component.ts
+++ b/projects/gameboard-ui/src/app/support/ticket-list/ticket-list.component.ts
@@ -164,7 +164,7 @@ export class TicketListComponent implements OnInit, OnDestroy {
   }
 
   downloadTicketDetailReport() {
-    this.reportApi.exportTicketDetails();
+    this.reportApi.exportTicketDetails({ term: this.searchText, filter: [this.statusFilter.toLowerCase(), this.assignFilter.toLowerCase()] });
   }
 
 }


### PR DESCRIPTION
- Ticket details, day stats, label stats, and challenge stats can be filtered by game and datetime and exported to a CSV via `Support > Support Reports`
  - Ticket details can also be filtered by a search term, ticket status, or assignment status on the ticket list page
- txt files can now be uploaded and previewed in support tickets