### PR TITLE
Miscellaneous admin and frontend improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "bootstrap": "^4.6.2",
     "jquery": "^3.6.0",
     "jquery-ui-dist": "^1.13.1",
+    "linkify-html": "^3.0.5",
+    "linkifyjs": "^3.0.5",
     "ngx-bootstrap": "^9.0.0",
     "ngx-markdown": "^14.0.1",
     "oidc-client": "^1.11.5",

--- a/projects/gameboard-ui/src/app/admin/participation-report/participation-report.component.html
+++ b/projects/gameboard-ui/src/app/admin/participation-report/participation-report.component.html
@@ -46,80 +46,90 @@
 <h5 class="pt-5 border-top">Series</h5>
 <div class="container pt-4" *ngIf="series; else loading">
   <div class="row border-top p-3">
-    <div class="col-3 font-weight-bold">Series</div>
-    <div class="col-3 font-weight-bold">Game Count</div>
-    <div class="col-3 font-weight-bold">Player Count</div>
-    <div class="col-3 font-weight-bold">Players with Sessions Count</div>
+    <div class="col-4 font-weight-bold">Series</div>
+    <div class="col-2 font-weight-bold">Game Count</div>
+    <div class="col-2 font-weight-bold">Player Count</div>
+    <div class="col-2 font-weight-bold">Players with Sessions Count</div>
+    <div class="col-2 font-weight-bold">Challenges Deployed Count</div>
   </div>
   <div class="row border-top p-3" *ngFor="let s of series.stats">
-    <div class="col-3">{{s.key}}</div>
-    <div class="col-3">{{s.gameCount}}</div>
-    <div class="col-3">{{s.playerCount}}</div>
-    <div class="col-3">{{s.sessionPlayerCount}}</div>
+    <div class="col-4">{{s.key}}</div>
+    <div class="col-2">{{s.gameCount}}</div>
+    <div class="col-2">{{s.playerCount}}</div>
+    <div class="col-2">{{s.sessionPlayerCount}}</div>
+    <div class="col-2">{{s.challengesDeployedCount}}</div>
   </div>
 </div>
 
 <h5 class="pt-5">Tracks</h5>
 <div class="container pt-4" *ngIf="tracks; else loading">
   <div class="row border-top p-3">
-    <div class="col-3 font-weight-bold">Track</div>
-    <div class="col-3 font-weight-bold">Game Count</div>
-    <div class="col-3 font-weight-bold">Player Count</div>
-    <div class="col-3 font-weight-bold">Players with Sessions Count</div>
+    <div class="col-4 font-weight-bold">Track</div>
+    <div class="col-2 font-weight-bold">Game Count</div>
+    <div class="col-2 font-weight-bold">Player Count</div>
+    <div class="col-2 font-weight-bold">Players with Sessions Count</div>
+    <div class="col-2 font-weight-bold">Challenges Deployed Count</div>
   </div>
   <div class="row border-top p-3" *ngFor="let s of tracks.stats">
-    <div class="col-3">{{s.key}}</div>
-    <div class="col-3">{{s.gameCount}}</div>
-    <div class="col-3">{{s.playerCount}}</div>
-    <div class="col-3">{{s.sessionPlayerCount}}</div>
+    <div class="col-4">{{s.key}}</div>
+    <div class="col-2">{{s.gameCount}}</div>
+    <div class="col-2">{{s.playerCount}}</div>
+    <div class="col-2">{{s.sessionPlayerCount}}</div>
+    <div class="col-2">{{s.challengesDeployedCount}}</div>
   </div>
 </div>
 
 <h5 class="pt-5">Seasons</h5>
 <div class="container pt-4" *ngIf="seasons; else loading">
   <div class="row border-top p-3">
-    <div class="col-3 font-weight-bold">Season</div>
-    <div class="col-3 font-weight-bold">Game Count</div>
-    <div class="col-3 font-weight-bold">Player Count</div>
-    <div class="col-3 font-weight-bold">Players with Sessions Count</div>
+    <div class="col-4 font-weight-bold">Season</div>
+    <div class="col-2 font-weight-bold">Game Count</div>
+    <div class="col-2 font-weight-bold">Player Count</div>
+    <div class="col-2 font-weight-bold">Players with Sessions Count</div>
+    <div class="col-2 font-weight-bold">Challenges Deployed Count</div>
   </div>
   <div class="row border-top p-3" *ngFor="let s of seasons.stats">
-    <div class="col-3">{{s.key}}</div>
-    <div class="col-3">{{s.gameCount}}</div>
-    <div class="col-3">{{s.playerCount}}</div>
-    <div class="col-3">{{s.sessionPlayerCount}}</div>
+    <div class="col-4">{{s.key}}</div>
+    <div class="col-2">{{s.gameCount}}</div>
+    <div class="col-2">{{s.playerCount}}</div>
+    <div class="col-2">{{s.sessionPlayerCount}}</div>
+    <div class="col-2">{{s.challengesDeployedCount}}</div>
   </div>
 </div>
 
 <h5 class="pt-5">Divisions</h5>
 <div class="container pt-4" *ngIf="divisions; else loading">
   <div class="row border-top p-3">
-    <div class="col-3 font-weight-bold">Division</div>
-    <div class="col-3 font-weight-bold">Game Count</div>
-    <div class="col-3 font-weight-bold">Player Count</div>
-    <div class="col-3 font-weight-bold">Players with Sessions Count</div>
+    <div class="col-4 font-weight-bold">Division</div>
+    <div class="col-2 font-weight-bold">Game Count</div>
+    <div class="col-2 font-weight-bold">Player Count</div>
+    <div class="col-2 font-weight-bold">Players with Sessions Count</div>
+    <div class="col-2 font-weight-bold">Challenges Deployed Count</div>
   </div>
   <div class="row border-top p-3" *ngFor="let s of divisions.stats">
-    <div class="col-3">{{s.key}}</div>
-    <div class="col-3">{{s.gameCount}}</div>
-    <div class="col-3">{{s.playerCount}}</div>
-    <div class="col-3">{{s.sessionPlayerCount}}</div>
+    <div class="col-4">{{s.key}}</div>
+    <div class="col-2">{{s.gameCount}}</div>
+    <div class="col-2">{{s.playerCount}}</div>
+    <div class="col-2">{{s.sessionPlayerCount}}</div>
+    <div class="col-2">{{s.challengesDeployedCount}}</div>
   </div>
 </div>
 
 <h5 class="pt-5">Modes</h5>
 <div class="container pt-4" *ngIf="modes; else loading">
   <div class="row border-top p-3">
-    <div class="col-3 font-weight-bold">Mode</div>
-    <div class="col-3 font-weight-bold">Game Count</div>
-    <div class="col-3 font-weight-bold">Player Count</div>
-    <div class="col-3 font-weight-bold">Players with Sessions Count</div>
+    <div class="col-4 font-weight-bold">Mode</div>
+    <div class="col-2 font-weight-bold">Game Count</div>
+    <div class="col-2 font-weight-bold">Player Count</div>
+    <div class="col-2 font-weight-bold">Players with Sessions Count</div>
+    <div class="col-2 font-weight-bold">Challenges Deployed Count</div>
   </div>
   <div class="row border-top p-3" *ngFor="let s of modes.stats">
-    <div class="col-3">{{s.key}}</div>
-    <div class="col-3">{{s.gameCount}}</div>
-    <div class="col-3">{{s.playerCount}}</div>
-    <div class="col-3">{{s.sessionPlayerCount}}</div>
+    <div class="col-4">{{s.key}}</div>
+    <div class="col-2">{{s.gameCount}}</div>
+    <div class="col-2">{{s.playerCount}}</div>
+    <div class="col-2">{{s.sessionPlayerCount}}</div>
+    <div class="col-2">{{s.challengesDeployedCount}}</div>
   </div>
 </div>
 

--- a/projects/gameboard-ui/src/app/admin/participation-report/participation-report.component.html
+++ b/projects/gameboard-ui/src/app/admin/participation-report/participation-report.component.html
@@ -46,17 +46,21 @@
 <h5 class="pt-5 border-top">Series</h5>
 <div class="container pt-4" *ngIf="series; else loading">
   <div class="row border-top p-3">
-    <div class="col-4 font-weight-bold">Series</div>
-    <div class="col-2 font-weight-bold">Game Count</div>
-    <div class="col-2 font-weight-bold">Player Count</div>
-    <div class="col-2 font-weight-bold">Players with Sessions Count</div>
-    <div class="col-2 font-weight-bold">Challenges Deployed Count</div>
+    <div class="col-3 font-weight-bold">Series</div>
+    <div class="col-1 font-weight-bold">Game Count</div>
+    <div class="col-1 font-weight-bold">Player Count</div>
+    <div class="col-2 font-weight-bold">Players with Sessions</div>
+    <div class="col-1 font-weight-bold">Team Count</div>
+    <div class="col-2 font-weight-bold">Teams with Sessions</div>
+    <div class="col-2 font-weight-bold">Challenges Deployed</div>
   </div>
   <div class="row border-top p-3" *ngFor="let s of series.stats">
-    <div class="col-4">{{s.key}}</div>
-    <div class="col-2">{{s.gameCount}}</div>
-    <div class="col-2">{{s.playerCount}}</div>
+    <div class="col-3">{{s.key}}</div>
+    <div class="col-1">{{s.gameCount}}</div>
+    <div class="col-1">{{s.playerCount}}</div>
     <div class="col-2">{{s.sessionPlayerCount}}</div>
+    <div class="col-1">{{s.teamCount}}</div>
+    <div class="col-2">{{s.sessionTeamCount}}</div>
     <div class="col-2">{{s.challengesDeployedCount}}</div>
   </div>
 </div>
@@ -64,17 +68,21 @@
 <h5 class="pt-5">Tracks</h5>
 <div class="container pt-4" *ngIf="tracks; else loading">
   <div class="row border-top p-3">
-    <div class="col-4 font-weight-bold">Track</div>
-    <div class="col-2 font-weight-bold">Game Count</div>
-    <div class="col-2 font-weight-bold">Player Count</div>
-    <div class="col-2 font-weight-bold">Players with Sessions Count</div>
-    <div class="col-2 font-weight-bold">Challenges Deployed Count</div>
+    <div class="col-3 font-weight-bold">Series</div>
+    <div class="col-1 font-weight-bold">Game Count</div>
+    <div class="col-1 font-weight-bold">Player Count</div>
+    <div class="col-2 font-weight-bold">Players with Sessions</div>
+    <div class="col-1 font-weight-bold">Team Count</div>
+    <div class="col-2 font-weight-bold">Teams with Sessions</div>
+    <div class="col-2 font-weight-bold">Challenges Deployed</div>
   </div>
   <div class="row border-top p-3" *ngFor="let s of tracks.stats">
-    <div class="col-4">{{s.key}}</div>
-    <div class="col-2">{{s.gameCount}}</div>
-    <div class="col-2">{{s.playerCount}}</div>
+    <div class="col-3">{{s.key}}</div>
+    <div class="col-1">{{s.gameCount}}</div>
+    <div class="col-1">{{s.playerCount}}</div>
     <div class="col-2">{{s.sessionPlayerCount}}</div>
+    <div class="col-1">{{s.teamCount}}</div>
+    <div class="col-2">{{s.sessionTeamCount}}</div>
     <div class="col-2">{{s.challengesDeployedCount}}</div>
   </div>
 </div>
@@ -82,17 +90,21 @@
 <h5 class="pt-5">Seasons</h5>
 <div class="container pt-4" *ngIf="seasons; else loading">
   <div class="row border-top p-3">
-    <div class="col-4 font-weight-bold">Season</div>
-    <div class="col-2 font-weight-bold">Game Count</div>
-    <div class="col-2 font-weight-bold">Player Count</div>
-    <div class="col-2 font-weight-bold">Players with Sessions Count</div>
-    <div class="col-2 font-weight-bold">Challenges Deployed Count</div>
+    <div class="col-3 font-weight-bold">Series</div>
+    <div class="col-1 font-weight-bold">Game Count</div>
+    <div class="col-1 font-weight-bold">Player Count</div>
+    <div class="col-2 font-weight-bold">Players with Sessions</div>
+    <div class="col-1 font-weight-bold">Team Count</div>
+    <div class="col-2 font-weight-bold">Teams with Sessions</div>
+    <div class="col-2 font-weight-bold">Challenges Deployed</div>
   </div>
   <div class="row border-top p-3" *ngFor="let s of seasons.stats">
-    <div class="col-4">{{s.key}}</div>
-    <div class="col-2">{{s.gameCount}}</div>
-    <div class="col-2">{{s.playerCount}}</div>
+    <div class="col-3">{{s.key}}</div>
+    <div class="col-1">{{s.gameCount}}</div>
+    <div class="col-1">{{s.playerCount}}</div>
     <div class="col-2">{{s.sessionPlayerCount}}</div>
+    <div class="col-1">{{s.teamCount}}</div>
+    <div class="col-2">{{s.sessionTeamCount}}</div>
     <div class="col-2">{{s.challengesDeployedCount}}</div>
   </div>
 </div>
@@ -100,17 +112,21 @@
 <h5 class="pt-5">Divisions</h5>
 <div class="container pt-4" *ngIf="divisions; else loading">
   <div class="row border-top p-3">
-    <div class="col-4 font-weight-bold">Division</div>
-    <div class="col-2 font-weight-bold">Game Count</div>
-    <div class="col-2 font-weight-bold">Player Count</div>
-    <div class="col-2 font-weight-bold">Players with Sessions Count</div>
-    <div class="col-2 font-weight-bold">Challenges Deployed Count</div>
+    <div class="col-3 font-weight-bold">Series</div>
+    <div class="col-1 font-weight-bold">Game Count</div>
+    <div class="col-1 font-weight-bold">Player Count</div>
+    <div class="col-2 font-weight-bold">Players with Sessions</div>
+    <div class="col-1 font-weight-bold">Team Count</div>
+    <div class="col-2 font-weight-bold">Teams with Sessions</div>
+    <div class="col-2 font-weight-bold">Challenges Deployed</div>
   </div>
   <div class="row border-top p-3" *ngFor="let s of divisions.stats">
-    <div class="col-4">{{s.key}}</div>
-    <div class="col-2">{{s.gameCount}}</div>
-    <div class="col-2">{{s.playerCount}}</div>
+    <div class="col-3">{{s.key}}</div>
+    <div class="col-1">{{s.gameCount}}</div>
+    <div class="col-1">{{s.playerCount}}</div>
     <div class="col-2">{{s.sessionPlayerCount}}</div>
+    <div class="col-1">{{s.teamCount}}</div>
+    <div class="col-2">{{s.sessionTeamCount}}</div>
     <div class="col-2">{{s.challengesDeployedCount}}</div>
   </div>
 </div>
@@ -118,17 +134,21 @@
 <h5 class="pt-5">Modes</h5>
 <div class="container pt-4" *ngIf="modes; else loading">
   <div class="row border-top p-3">
-    <div class="col-4 font-weight-bold">Mode</div>
-    <div class="col-2 font-weight-bold">Game Count</div>
-    <div class="col-2 font-weight-bold">Player Count</div>
-    <div class="col-2 font-weight-bold">Players with Sessions Count</div>
-    <div class="col-2 font-weight-bold">Challenges Deployed Count</div>
+    <div class="col-3 font-weight-bold">Series</div>
+    <div class="col-1 font-weight-bold">Game Count</div>
+    <div class="col-1 font-weight-bold">Player Count</div>
+    <div class="col-2 font-weight-bold">Players with Sessions</div>
+    <div class="col-1 font-weight-bold">Team Count</div>
+    <div class="col-2 font-weight-bold">Teams with Sessions</div>
+    <div class="col-2 font-weight-bold">Challenges Deployed</div>
   </div>
   <div class="row border-top p-3" *ngFor="let s of modes.stats">
-    <div class="col-4">{{s.key}}</div>
-    <div class="col-2">{{s.gameCount}}</div>
-    <div class="col-2">{{s.playerCount}}</div>
+    <div class="col-3">{{s.key}}</div>
+    <div class="col-1">{{s.gameCount}}</div>
+    <div class="col-1">{{s.playerCount}}</div>
     <div class="col-2">{{s.sessionPlayerCount}}</div>
+    <div class="col-1">{{s.teamCount}}</div>
+    <div class="col-2">{{s.sessionTeamCount}}</div>
     <div class="col-2">{{s.challengesDeployedCount}}</div>
   </div>
 </div>

--- a/projects/gameboard-ui/src/app/admin/support-report/support-report.component.html
+++ b/projects/gameboard-ui/src/app/admin/support-report/support-report.component.html
@@ -69,24 +69,24 @@
   </div>
 
   <div class="container" [hidden]="!showDays">
-    <table class="table mb-1">
+    <table class="table mb-1" *ngIf="dayStats$ | async as report; else loading">
       <thead class="thead-dark border-0 table-header">
         <tr>
           <th>Day</th>
-          <th class="text-center">8:00am-4:00pm ET</th>
-          <th class="text-center">4:00pm-11:00pm ET</th>
+          <th class="text-center" *ngFor="let shift of report.shifts">{{shift[0]}}-{{shift[1]}} {{report.timezone}}</th>
           <th class="text-center">Outside of Shifts</th>
           <th class="text-center">Total Created</th>
         </tr>
       </thead>
-      <tbody *ngIf="dayStats$ | async as stats; else loading">
-        <tr *ngFor="let stat of stats">
+      <tbody>
+        <tr *ngFor="let stat of report.ticketDays">
           <td>
             <div class="font-weight-bold">{{stat.dayOfWeek}}</div>
             <small>{{stat.date}}</small>
           </td>
-          <td class="text-center"><div>{{stat.shift1Count}}</div></td>
-          <td class="text-center"><div>{{stat.shift2Count}}</div></td>
+          <td *ngFor="let count of stat.shiftCounts" class="text-center">
+            <div>{{count}}</div>
+          </td>
           <td class="text-center"><div>{{stat.outsideShiftCount}}</div></td>
           <td class="text-center"><div>{{stat.count}}</div></td>
         </tr>

--- a/projects/gameboard-ui/src/app/admin/support-report/support-report.component.ts
+++ b/projects/gameboard-ui/src/app/admin/support-report/support-report.component.ts
@@ -5,7 +5,7 @@ import { switchMap, tap } from 'rxjs/operators';
 import { Game } from '../../api/game-models';
 import { GameService } from '../../api/game.service';
 import { ReportService } from '../../api/report.service';
-import { TicketChallengeGroup, TicketDayGroup, TicketLabelGroup } from '../../api/support-models';
+import { TicketChallengeGroup, TicketDayGroup, TicketDayReport, TicketLabelGroup } from '../../api/support-models';
 
 @Component({
   selector: 'app-support-report',
@@ -24,7 +24,7 @@ export class SupportReportComponent implements OnInit {
   endRange?: Date;
   search: any = {};
 
-  dayStats$: Observable<TicketDayGroup[]>;
+  dayStats$: Observable<TicketDayReport>;
   labelStats$: Observable<TicketLabelGroup[]>;
   challengeStats$: Observable<TicketChallengeGroup[]>;
 

--- a/projects/gameboard-ui/src/app/api/report-models.ts
+++ b/projects/gameboard-ui/src/app/api/report-models.ts
@@ -94,6 +94,7 @@ export interface ParticipationStat {
   gameCount: number;
   playerCount: number;
   sessionPlayerCount: number;
+  challengesDeployedCount: number;
 }
 
 export interface CorrelationReport {

--- a/projects/gameboard-ui/src/app/api/report-models.ts
+++ b/projects/gameboard-ui/src/app/api/report-models.ts
@@ -116,6 +116,8 @@ export interface ParticipationStat {
   gameCount: number;
   playerCount: number;
   sessionPlayerCount: number;
+  teamCount: number;
+  sessionTeamCount: number;
   challengesDeployedCount: number;
 }
 

--- a/projects/gameboard-ui/src/app/api/support-models.ts
+++ b/projects/gameboard-ui/src/app/api/support-models.ts
@@ -129,12 +129,17 @@ export interface TicketActivity {
   assignee: UserSummary;
 }
 
+export interface TicketDayReport {
+  shifts: string[][];
+  timezone: string;
+  ticketDays: TicketDayGroup[];
+}
+
 export interface TicketDayGroup {
   date: string;
   dayOfWeek: string;
   count: number;
-  shift1Count: number;
-  shift2Count: number;
+  shiftCounts: number[];
   outsideShiftCount: number;
 }
 

--- a/projects/gameboard-ui/src/app/app.component.html
+++ b/projects/gameboard-ui/src/app/app.component.html
@@ -13,7 +13,7 @@
         <span>Support</span>
         <app-support-pill></app-support-pill>
       </a>
-      <a *ngIf="!!user && (user.isAdmin || user.isDirector || user.isRegistrar || user.isDesigner || user.isObserver)" class="btn btn-link text-success mx-1" routerLinkActive="text-info" [routerLink]="['/admin']">Admin</a>
+      <a *ngIf="!!user && (user.isAdmin || user.isDirector || user.isRegistrar || user.isDesigner || user.isObserver || user.isSupport)" class="btn btn-link text-success mx-1" routerLinkActive="text-info" [routerLink]="['/admin']">Admin</a>
       <a *ngIf="!!user" class="btn btn-link text-success mx-1" (click)="logout()">Logout</a>
     </ng-container>
   </div>

--- a/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.ts
+++ b/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.ts
@@ -5,7 +5,7 @@ import { AfterViewInit, Component, OnDestroy, OnInit, Renderer2 } from '@angular
 import { ActivatedRoute, Router } from '@angular/router';
 import { faArrowLeft, faBolt, faExclamationTriangle, faTrash, faTv } from '@fortawesome/free-solid-svg-icons';
 import { asyncScheduler, combineLatest, interval, merge, Observable, of, scheduled, Subject, Subscription, timer } from 'rxjs';
-import { catchError, combineAll, filter, map, mergeAll, switchMap, takeUntil, takeWhile, tap } from 'rxjs/operators';
+import { catchError, combineAll, debounceTime, filter, map, mergeAll, switchMap, takeUntil, takeWhile, tap } from 'rxjs/operators';
 import { BoardPlayer, BoardSpec, Challenge, NewChallenge, VmState } from '../../api/board-models';
 import { BoardService } from '../../api/board.service';
 import { ApiUser } from '../../api/user-models';
@@ -66,6 +66,7 @@ export class GameboardPageComponent implements OnInit, AfterViewInit, OnDestroy 
       this.refresh$
     ).pipe(
       filter(id => !!id),
+      debounceTime(100),
       switchMap(id => api.load(id).pipe(
         catchError(err => of({} as BoardPlayer))
       )),

--- a/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.html
+++ b/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.html
@@ -62,7 +62,7 @@
             </div>
           </div>
           <div class="card-body" style="min-height:100px;">
-            <p *ngIf="!editingContent" class="card-text" [innerText]="ctx.ticket.description"></p>
+            <p *ngIf="!editingContent" class="card-text" id="card-desc">{{ detectLinks(ctx.ticket.description, "card-desc") }}</p>
             <ng-container *ngIf="editingContent && changedTicket && !!changedTicket?.id">
               <textarea type="text" class="form-control w-100 text-white" rows=8  autocomplete="off" style="background:#000"
               [(ngModel)]="changedTicket.description"></textarea>
@@ -134,7 +134,7 @@
                 </div>
               </div>
               <div class="card-body">
-                <p class="card-text" [innerText]="activity.message" style="max-height: 300px; overflow-y:auto"></p>
+                <p class="card-text" style="max-height: 300px; overflow-y:auto" id="{{activity.id}}">{{ detectLinks(activity.message, activity.id) }}</p>
                 <div *ngIf="activity.attachmentFiles?.length" class="d-flex overflow-auto my-auto">
                   <ng-container *ngFor="let file of activity.attachmentFiles; let j = index;">
                     <div class="attachment m-2" (click)="enlarge(activity.attachmentFiles, j, commentAttachmentMap.get(activity.id))">

--- a/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.ts
+++ b/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.ts
@@ -15,6 +15,8 @@ import { EditData, SuggestionOption } from '../../utility/components/inplace-edi
 import { ConfigService } from '../../utility/config.service';
 import { UserService as LocalUserService } from '../../utility/user.service';
 import { NotificationService } from '../../utility/notification.service';
+import * as linkify from 'linkifyjs';
+import linkifyHtml from 'linkify-html';
 
 @Component({
   selector: 'app-ticket-details',
@@ -485,4 +487,8 @@ export class TicketDetailsComponent implements OnInit, AfterViewInit, OnDestroy 
     );
   }
 
+  public detectLinks(body: string, id: string): void {
+    var elem = document.getElementById(id);
+    if (elem) elem.innerHTML = linkifyHtml(body, { nl2br: true });
+  }
 }

--- a/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.ts
+++ b/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.ts
@@ -490,6 +490,6 @@ export class TicketDetailsComponent implements OnInit, AfterViewInit, OnDestroy 
 
   public detectLinks(body: string, id: string): void {
     var elem = document.getElementById(id);
-    if (elem) elem.innerHTML = linkifyHtml(body, { nl2br: true });
+    if (elem && body) elem.innerHTML = linkifyHtml(body, { nl2br: true });
   }
 }

--- a/projects/gameboard-ui/src/app/utility/admin.guard.ts
+++ b/projects/gameboard-ui/src/app/utility/admin.guard.ts
@@ -2,9 +2,9 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, CanLoad, Route, Router, RouterStateSnapshot, UrlSegment, UrlTree } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, CanLoad, NavigationStart, Route, Router, RouterStateSnapshot, UrlSegment, UrlTree } from '@angular/router';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 import { UserService } from './user.service';
 
 @Injectable({
@@ -12,12 +12,20 @@ import { UserService } from './user.service';
 })
 export class AdminGuard implements CanActivate, CanActivateChild, CanLoad {
 
+  destinationUrl: string = "";
+
   constructor(
     private userSvc: UserService,
     private router: Router
   ){
-
+    this.router.events.pipe(
+      filter((e): e is NavigationStart => e instanceof NavigationStart)
+    ).subscribe((e: NavigationStart) => {
+      console.log(e.url);
+      this.destinationUrl = e.url;
+    });
   }
+
   canActivate(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
@@ -36,8 +44,12 @@ export class AdminGuard implements CanActivate, CanActivateChild, CanLoad {
 
   private validateRole(): Observable<boolean | UrlTree> {
     return this.userSvc.user$.pipe(
-      map(u => u?.isRegistrar || u?.isDirector || u?.isAdmin || u?.isObserver || false),
+      map(u => u?.isRegistrar || u?.isDirector || u?.isAdmin || u?.isObserver || (u?.isSupport && this.isLinkAllowedForSupportRole()) || false),
       map(v => v ? v : this.router.parseUrl('/forbidden'))
     );
+  }
+
+  private isLinkAllowedForSupportRole(): boolean {
+    return !(this.destinationUrl.startsWith("/admin/registrar") || this.destinationUrl.startsWith("admin/designer"));
   }
 }

--- a/projects/gameboard-ui/src/app/utility/admin.guard.ts
+++ b/projects/gameboard-ui/src/app/utility/admin.guard.ts
@@ -50,6 +50,8 @@ export class AdminGuard implements CanActivate, CanActivateChild, CanLoad {
   }
 
   private isLinkAllowedForSupportRole(): boolean {
-    return !(this.destinationUrl.startsWith("/admin/registrar") || this.destinationUrl.startsWith("admin/designer"));
+    return !(this.destinationUrl.startsWith("/admin/registrar") 
+          || this.destinationUrl.startsWith("/admin/designer")
+          || this.destinationUrl.startsWith("/admin/report"));
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,9 @@
     "lib": [
       "es2018",
       "dom"
-    ]
+    ],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
- Support roles now have limited administrative abilities, able to access admin challenge metrics and observe challenges
  - Support roles are blocked off from accessing certain pages like `admin/registrar` and `admin/designer`
- New fields added to participation reports:
  - **Team Count**: the number of teams who enrolled for a game across a given participation metric
  - **Teams with Sessions Count**: the number of teams who began a session for a game across a given participation metric
  - **Number of Challenges Deployed**: the number of challenges deployed across a given participation metric
- Participation reports render new fields in UI and via CSV export
- Links in ticket descriptions and ticket comments now highlight automatically
- Ticket support shifts are no longer locked to just two shifts and populate dynamically in the UI
- Board reports now accurately calculate the number of teams with one sponsor and display another row for the number of teams with multiple sponsors
- Brief debounce added to buffer refresh requests