### PR TITLE
UI information adjustments

### DIFF
--- a/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.html
+++ b/projects/gameboard-ui/src/app/admin/game-editor/game-editor.component.html
@@ -195,7 +195,8 @@
       rank &mdash; Final leaderboard ranking of the player
       leaderboard_name &mdash; Approved name for either team or individual
       date &mdash; Date player's session ended for this game
-      player_count &mdash; Number of players who participated in this game</pre>
+      player_count &mdash; Number of players who participated in this game
+      team_count &mdash; Number of teams who participated in this game</pre>
             <p class="cert-info mb-2">
       Tip: Create an outer div with fixed height and width and <code>position: relative</code>. Create inner divs with <code>position: absolute; text-align: center;</code> and set textbox width and X/Y position with <code>top: __px; left: __px; width: __px;</code>.
       To add a background image, use <code>background-size: 100% 100%; background-image: url('URL_HERE');</code>

--- a/projects/gameboard-ui/src/app/admin/sponsor-browser/sponsor-browser.component.html
+++ b/projects/gameboard-ui/src/app/admin/sponsor-browser/sponsor-browser.component.html
@@ -12,18 +12,27 @@
 <h4>Sponsors</h4>
 
 <app-dropzone (dropped)="dropped($event)">
-  <span>or drag sponsor images here. (Filename should be the sponsor key.)</span>
+  <span> or drag sponsor images here. (Filename should be the sponsor key.)</span>
+  <br>
+  <span>Acceptable file types: .png, .jpeg, .jpg, .gif, .webp, .svg</span>
 </app-dropzone>
 
 <ng-container *ngIf="source$ | async as sponsors; else loading">
-  <div *ngFor="let s of sponsors" class="panel">
-    <img [src]="s.logoUrl" class="img-fluid">
-    <span class="mx-2">{{s.id}}</span>
-    <input type="text" class="form-control mx-2" placeholder="title" [(ngModel)]="s.name" (blur)="update(s)">
-    <app-confirm-button btnClass="btn btn-outline-danger" (confirm)="delete(s)">
-      <fa-icon [icon]="faTrash"></fa-icon>
-      <span>Delete</span>
-    </app-confirm-button>
+  <br>
+  <div style="display: table-row-group">
+    <div *ngFor="let s of sponsors" class="panel" style="display: table-row">
+      <div style="display: table-cell; padding: 8px">
+        <img [src]="s.logoUrl" class="img-fluid">
+        <span class="mx-2">{{s.id}}</span>
+      </div>
+      <div style="display: table-cell">
+        <input type="text" class="form-control mx-2" placeholder="title" [(ngModel)]="s.name" (blur)="update(s)">
+        <app-confirm-button btnClass="btn btn-outline-danger" (confirm)="delete(s)">
+          <fa-icon [icon]="faTrash"></fa-icon>
+          <span>Delete</span>
+        </app-confirm-button>
+      </div>
+  </div>
   </div>
 </ng-container>
 

--- a/projects/gameboard-ui/src/app/game/game-page/game-page.component.html
+++ b/projects/gameboard-ui/src/app/game/game-page/game-page.component.html
@@ -27,8 +27,8 @@
       <markdown [data]="ctx.game.gameMarkdown"></markdown>
     </div>
 
-     <!-- if auth'd, enrolled, game ended, and certificate defined -->
-     <ng-container *ngIf="!!ctx.user.id && !!ctx.player.id && ctx.game.hasEnded && !!ctx.game.certificateTemplate">
+     <!-- if auth'd, enrolled, opened a session, game ended, and certificate defined -->
+     <ng-container *ngIf="!!ctx.user.id && !!ctx.player.id && !!ctx.player.sessionEnd && ctx.player.sessionEnd.toString() != '-infinity' && ctx.player.sessionEnd > minDate && ctx.game.hasEnded && !!ctx.game.certificateTemplate">
       <div class="row justify-content-center">
         <div class="col panel">
           <div tabindex="0" (click)="showCert = !showCert">

--- a/projects/gameboard-ui/src/app/game/game-page/game-page.component.ts
+++ b/projects/gameboard-ui/src/app/game/game-page/game-page.component.ts
@@ -25,6 +25,7 @@ export class GamePageComponent implements OnInit {
   faList = faListOl;
   faCaretDown = faCaretDown; 
   faCaretRight = faCaretRight;
+  minDate = new Date(1, 1, 1, 0, 0, 0, 0);
   constructor(
     router: Router,
     route: ActivatedRoute,

--- a/projects/gameboard-ui/src/app/home/home.module.ts
+++ b/projects/gameboard-ui/src/app/home/home.module.ts
@@ -44,7 +44,7 @@ import { CertificateListComponent } from './certificate-list/certificate-list.co
         { path: 'profile/certificates', component: CertificateListComponent, canActivate: [AuthGuard] },
         { path: 'doc/:id', component: TocPageComponent },
         { path: 'forbidden', component: ForbiddenComponent },
-        { path: 'home', component: LandingComponent }
+        { path: 'home', component: LandingComponent, canActivate: [AuthGuard]  }
       ]},
       { path: '**', redirectTo: '/home' }
     ]),

--- a/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.html
+++ b/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.html
@@ -53,7 +53,7 @@
             <div>
                 <span class="mr-1 font-weight-bold">{{ctx.ticket.requester?.approvedName}}</span>
                 <span *ngIf="!ctx.ticket.selfCreated" class="mr-1 font-weight-bold">(by {{ctx.ticket.creator?.approvedName}})</span>
-                <span [tooltip]="ctx.ticket.created | shorttime" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">
+                <span [tooltip]="ctx.ticket.created | shorttime: false : true" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">
                   {{ctx.ticket.created | ago}}
                 </span>
             </div>
@@ -103,14 +103,17 @@
                     <div >
                       <button *ngIf="!newCommentFocus" class="btn text-info btn-link" (click)="toggleAttachments = !toggleAttachments; newCommentFocus = true"><fa-icon [icon]="faPaperclip"></fa-icon> Attach</button>
                     </div>
-                    <div>
-                      <button *ngIf="newCommentFocus" class="btn text-info btn-link ml-1" (click)="newCommentFocus = false">Cancel</button>
-                      <button class="btn btn-info py-1" [disabled]="!newCommentText && !newCommentAttachments.length" (click)="addComment()">Comment</button>
-                    </div>
                   </div>
                   <div class="mt-2" [hidden]="!newCommentFocus">
                     <app-image-manager (added)="updateAttachments($event)" [reset$]="resetAttachments$"
                       [showIcon]="false" [defaultHeight]="70" browseButtonStyle="btn-outline-light"></app-image-manager>
+                  </div>
+                  <div class="mt-2 d-flex justify-content-between">
+                    <div></div>
+                    <div>
+                      <button *ngIf="newCommentFocus" class="btn text-info btn-link ml-1" (click)="newCommentFocus = false">Cancel</button>
+                      <button class="btn btn-info py-1" [disabled]="!newCommentText && !newCommentAttachments.length" (click)="addComment()">Comment</button>
+                    </div>
                   </div>
                 </ng-container>
               </div>
@@ -128,7 +131,7 @@
                 <div>
                   <span class="">
                     <div>
-                      <span class="font-weight-bold">{{activity.user?.approvedName}}</span>&nbsp;&middot;&nbsp;<div style="display: inline-block" [tooltip]="activity.timestamp | shorttime:true" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">{{activity.timestamp | ago}}</div>
+                      <span class="font-weight-bold">{{activity.user?.approvedName}}</span>&nbsp;&middot;&nbsp;<div style="display: inline-block" [tooltip]="activity.timestamp | shorttime: true : true" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">{{activity.timestamp | ago}}</div>
                     </div>
                   </span>
                 </div>
@@ -154,7 +157,7 @@
                   [class.badge-info]="activity.status == 'Open' || !activity.status"
                   [class.badge-success]="activity.status == 'In Progress'"
                   [class.badge-dark]="activity.status == 'Closed'">{{activity.status}}</span></div>
-                  <div style="display: inline-block" [tooltip]="activity.timestamp | shorttime:true" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">
+                  <div style="display: inline-block" [tooltip]="activity.timestamp | shorttime: true : true" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">
                     &nbsp;{{activity.timestamp | ago}}
                   </div>
               </span>
@@ -162,12 +165,12 @@
             <div class="my-3 mx-3 px-3 border-0 text-center" *ngIf="activity.type == 2"> <!-- Assignee Change -->
               <span class="text-center  py-2 d-flex rounded" style="background: black">
                 <span *ngIf="!!activity.assigneeId">Assigned to&nbsp;<span class="font-weight-bold">{{activity.assignee?.approvedName}}</span>
-                  <div style="display: inline-block" [tooltip]="activity.timestamp | shorttime:true" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">
+                  <div style="display: inline-block" [tooltip]="activity.timestamp | shorttime: true : true" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">
                     &nbsp;{{activity.timestamp | ago}}
                   </div>
                 </span>
                 <span *ngIf="!activity.assigneeId">Unassigned
-                  <div style="display: inline-block" [tooltip]="activity.timestamp | shorttime:true" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">
+                  <div style="display: inline-block" [tooltip]="activity.timestamp | shorttime: true : true" containerClass="light-tooltip" container="body" [adaptivePosition]="true" placement="top">
                     &nbsp;{{activity.timestamp | ago}}
                   </div>
                 </span>

--- a/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.scss
+++ b/projects/gameboard-ui/src/app/support/ticket-details/ticket-details.component.scss
@@ -110,3 +110,7 @@ textarea {
   opacity: 20%;
 }
 
+.btn-info:disabled {
+  background-color: rgb(108, 117, 125);
+  border-color: rgb(108, 117, 125);
+}

--- a/projects/gameboard-ui/src/app/utility/components/dropzone/dropzone.component.html
+++ b/projects/gameboard-ui/src/app/utility/components/dropzone/dropzone.component.html
@@ -5,7 +5,7 @@
 
   <label [for]="inputId">
     <input [id]="inputId" type="file" style="display:none;" (change)="filesSelected($event)">
-    <span [class]="btnClass">Browse</span>
+    <span style="border-color:white" class="text-white" [class]="btnClass">Browse</span>
   </label>
 
   <ng-content></ng-content>

--- a/projects/gameboard-ui/src/app/utility/components/image-manager/image-manager.component.html
+++ b/projects/gameboard-ui/src/app/utility/components/image-manager/image-manager.component.html
@@ -7,7 +7,7 @@
       <input id="fileSelector" type="file" style="display:none;" multiple (change)="filesSelected($event)">
       <span class="btn btn-sm" [class]="browseButtonStyle">Browse</span>
     </label>
-    <small> or drag files here. {{maxCombinedSizeMB}}MB limit.</small>
+    <small> or drag files here. {{maxCombinedSizeMB}}MB limit. Acceptable file types: .png, .jpeg, .jpg, .gif, .webp, .svg, .txt</small>
   </div>
   <div class="d-flex overflow-auto my-auto">
     <fa-icon *ngIf="showIcon && !files.size" class="background-icon mx-auto align-middle" [icon]="faUpload" size="lg"></fa-icon> 

--- a/projects/gameboard-ui/src/app/utility/config.service.ts
+++ b/projects/gameboard-ui/src/app/utility/config.service.ts
@@ -70,6 +70,25 @@ export class ConfigService {
     {...this.datedisplay_options, timeZoneName: 'short'}
   );
 
+  datedisplay_options_with_seconds: Intl.DateTimeFormatOptions = {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric'
+  };
+
+  _shortdate_formatter_with_seconds = new Intl.DateTimeFormat(
+    'en-US',
+    this.datedisplay_options_with_seconds
+  );
+
+  _shorttz_formatter_with_seconds = new Intl.DateTimeFormat(
+    'en-US',
+    {...this.datedisplay_options_with_seconds, timeZoneName: 'short' }
+  );
+
   constructor(
     private http: HttpClient,
     private location: Location,
@@ -117,6 +136,10 @@ export class ConfigService {
 
   get shorttz_formatter(): any {
     return this._shorttz_formatter;
+  }
+
+  get shorttz_formatter_with_seconds(): any {
+    return this._shorttz_formatter_with_seconds;
   }
 
   get lastSeenSupport(): Date {

--- a/projects/gameboard-ui/src/app/utility/pipes/short-time.pipe.ts
+++ b/projects/gameboard-ui/src/app/utility/pipes/short-time.pipe.ts
@@ -6,10 +6,10 @@ export class ShortTimePipe implements PipeTransform {
 
   constructor(private config: ConfigService) {}
 
-  transform(date: any, timeZone: boolean = false): string {
+  transform(date: any, timeZone: boolean = false, includeSeconds: boolean = false): string {
     const style = timeZone
-      ? this.config.shorttz_formatter
-      : this.config.shortdate_formatter
+      ? (includeSeconds ? this.config._shorttz_formatter_with_seconds : this.config.shorttz_formatter)
+      : (includeSeconds ? this.config._shortdate_formatter_with_seconds : this.config.shortdate_formatter)
     ;
     return style.format(new Date(date));
   }


### PR DESCRIPTION
- In ticket details:
  - Time tooltip can show seconds, and does show seconds on ticket details
  - Comment button is grayed out initially in ticket details and moved below attachments pane
  - Permitted file types shown for uploads for creating tickets and comments
- In sponsor uploads:
  - Desired filetype list added to dropzone
  - Sponsor list has regular length between columns
  - Browse button made more obvious by coloring its text and its border white
- ~~Homepage redirects to /login if not logged in~~ _Reverted in #57_
- Certificate changes:
  - Player count variable in certificates accurately counts players, counting them only if they completed a session in-game
  - Team count variable in certificates accurately counts teams under the same criteria
  - Players will only see a certificate in their certificate listing if they actually competed (AKA, finished a session)
  - Players will only be given the option to see a certificate in a game for the same reason
- Board reports made more accurate, showing sponsors even if they have no competitors