### PR TITLE
Bug fix: game boards with no active challenge throw errors

### DIFF
--- a/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.html
+++ b/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.html
@@ -110,7 +110,8 @@
 
             <markdown [data]="spec.instance!.state.markdown ||''"></markdown>
 
-            <markdown [data]="spec.instance!.state.challenge.text || ''"></markdown>
+            <markdown *ngIf="spec.instance?.state?.challenge" [data]="spec.instance!.state.challenge.text || ''">
+            </markdown>
 
             <ng-container *ngIf="!!spec.instance!.state && spec.instance!.state.isActive">
               <h3>Gamespace Resources</h3>


### PR DESCRIPTION
Resolves an error that occurred when players attempted to access a gameboard with no active challenge. 