### PR TITLE
Hotfix: unity games URL "sessionEnd" format

### DIFF
--- a/projects/gameboard-ui/src/app/game/player-session/player-session.component.html
+++ b/projects/gameboard-ui/src/app/game/player-session/player-session.component.html
@@ -144,7 +144,7 @@
           <a *ngIf="ctx.game.mode != 'unity'" class="btn btn-primary btn-lg"
             [routerLink]="['../board', ctx.player.id]">Continue to Gameboard</a>
           <a *ngIf="ctx.game.mode == 'unity'" class="btn btn-primary bgn-lg"
-            [routerLink]="['../unity-board', ctx.player.gameId, ctx.player.id, ctx.player.teamId, ctx.player.sessionEnd]">
+            [routerLink]="['../unity-board', ctx.player.gameId, ctx.player.id, ctx.player.teamId, ctx.player.sessionEnd.toDateString()]">
             Continue to Cubespace
           </a>
         </div>


### PR DESCRIPTION
Corrected an issue where the session end was being improperly passed to the URL for Unity games.