### PR TITLE
fix table header alignment

### DIFF
--- a/projects/gameboard-ui/src/styles.scss
+++ b/projects/gameboard-ui/src/styles.scss
@@ -211,3 +211,14 @@ app-spinner svg {
 .custom-bg-purple {
   background-color: #424;
 }
+
+// reboot.css breaks th alignment, so set explicitly
+th[align="left"] {
+  text-align: left;
+}
+th[align="right"] {
+  text-align: right;
+}
+th[align="center"] {
+  text-align: center;
+}


### PR DESCRIPTION
Pretty minor... bootstrap/reboot breaks `<th align` attributes, so explicitly overriding reboot so that markdown tables render correctly.