### PR TITLE
Move the 'destroy' button for a game resources to a new line 

### DIFF
--- a/projects/gameboard-ui/src/app/admin/challenge-browser/challenge-browser.component.scss
+++ b/projects/gameboard-ui/src/app/admin/challenge-browser/challenge-browser.component.scss
@@ -1,5 +1,9 @@
 @import '../../../scss/variables';
 
+li {
+  list-style-type: circle;
+}
+
 .fixed {
   height: 75vh;
   position: relative;
@@ -14,6 +18,7 @@
   overflow-y: scroll;
 
 }
+
 .detail {
   display: inline-block;
   position: relative;
@@ -21,13 +26,16 @@
   height: 75vh;
   overflow-y: scroll;
 }
+
 .clickable {
   cursor: pointer;
   padding: .5rem;
 }
+
 .clickable:hover {
   background-color: darkslategrey;
 }
+
 .clicked {
   background-color: darken(darkslategrey, 5%);
 }
@@ -35,11 +43,13 @@
 // scroll bar to match theme
 ::-webkit-scrollbar {
   border-radius: 0.25rem;
-  background: $black; 
+  background: $black;
 }
+
 ::-webkit-scrollbar-thumb {
-  background: $dark; 
+  background: $dark;
 }
+
 ::-webkit-scrollbar-thumb:hover {
   background: darken($dark, 5%)
 }

--- a/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.html
+++ b/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.html
@@ -113,22 +113,30 @@
 
             <ng-container *ngIf="!!spec.instance!.state && spec.instance!.state.isActive">
               <h3>Gamespace Resources</h3>
-              <div *ngIf="!deploying && ctx.session.isDuring" class="d-flex my-4">
-                <button *ngFor="let vm of spec.instance!.state.vms" class="btn btn-sm btn-dark mr-2"
-                  (click)="console(vm)">
-                  <fa-icon [icon]="faTv"></fa-icon>
-                  <span>{{vm.name}}</span>
-                </button>
-                <app-confirm-button *ngIf="spec.instance!.state.vms?.length" btnClass="btn btn-sm btn-outline-warning"
-                  (confirm)="stop(spec)">
-                  <fa-icon [icon]="faTrash"></fa-icon>
-                  <span>Destroy</span>
-                </app-confirm-button>
-                <app-confirm-button *ngIf="!spec.instance!.state.vms?.length" btnClass="btn btn-sm btn-outline-warning"
-                  (confirm)="start(spec)">
-                  <fa-icon [icon]="faBolt"></fa-icon>
-                  <span>Deploy</span>
-                </app-confirm-button>
+              <div *ngIf="!deploying && ctx.session.isDuring">
+                <div class="vms-container my-4">
+                  <ul class="d-flex">
+                    <li *ngFor="let vm of spec.instance!.state.vms">
+                      <button class="btn btn-sm btn-dark mr-2" (click)="console(vm)">
+                        <fa-icon [icon]="faTv"></fa-icon>
+                        <span>{{vm.name}}</span>
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+
+                <div class="vm-controls-container my-4">
+                  <app-confirm-button *ngIf="spec.instance!.state.vms?.length" btnClass="btn btn-sm btn-outline-warning"
+                    (confirm)="stop(spec)">
+                    <fa-icon [icon]="faTrash"></fa-icon>
+                    <span>Destroy</span>
+                  </app-confirm-button>
+                  <app-confirm-button *ngIf="!spec.instance!.state.vms?.length"
+                    btnClass="btn btn-sm btn-outline-warning" (confirm)="start(spec)">
+                    <fa-icon [icon]="faBolt"></fa-icon>
+                    <span>Deploy</span>
+                  </app-confirm-button>
+                </div>
               </div>
               <div *ngIf="deploying" class="text-center">
                 <app-spinner></app-spinner>
@@ -138,7 +146,7 @@
             <h3 *ngIf="spec.instance!.state.challenge?.questions?.length">Challenge Questions</h3>
             <app-gamespace-quiz [spec]="spec!" [session]="ctx.session" (graded)="graded()"></app-gamespace-quiz>
 
-            <div *ngIf="spec.instance?.id" class="text-right m-4 ">
+            <div *ngIf="spec.instance?.id" class="text-right m-4">
               <div class="mb-1">
                 Need Challenge Support?
                 <span class="m-2 p-2">
@@ -153,7 +161,6 @@
                 <app-clipspan class="text-info m-2 p-2">{{spec.instance?.id | slice:0:8}} {{spec.tag}}</app-clipspan>
               </div>
             </div>
-
 
             <div *ngIf="spec.instance!.state.challenge && ctx.game.feedbackTemplate?.challenge?.length">
               <app-feedback-form [spec]="spec!" [specs$]="specs$" [game]="ctx.game" [session]="ctx.session"

--- a/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.scss
+++ b/projects/gameboard-ui/src/app/game/gameboard-page/gameboard-page.component.scss
@@ -2,19 +2,24 @@
   img {
     max-height: 150px;
   }
+
   span {
     font-size: 1.5rem;
   }
+
   .small-card {
     width: 120px;
   }
 }
+
 .mapbox {
   max-width: 800px;
 }
+
 .quizbox {
   max-width: 800px;
 }
+
 .mapbox-dot {
   fill: lime;
   stroke: lime;
@@ -22,6 +27,7 @@
   stroke-opacity: 1;
   stroke-width: .25;
 }
+
 .callout {
   position: absolute;
   z-index: 10;
@@ -33,9 +39,11 @@
 .countdown-green {
   color: rgb(0, 191, 0);
 }
+
 .countdown-yellow {
   color: rgb(236, 236, 130);
 }
+
 .countdown-red {
   color: rgb(255, 53, 53);
 }
@@ -45,4 +53,9 @@ iframe {
   // aspect-ratio: 16 / 10;
   margin: auto;
   display: block
+}
+
+.vms-container ul {
+  padding: 0;
+  padding-inline-start: 0;
 }

--- a/projects/gameboard-ui/src/app/game/player-session/player-session.component.scss
+++ b/projects/gameboard-ui/src/app/game/player-session/player-session.component.scss
@@ -1,3 +1,7 @@
+alert li {
+  list-style-type: circle;
+}
+
 .forecast {
   max-width: 400px;
   margin: 0 auto;

--- a/projects/gameboard-ui/src/styles.scss
+++ b/projects/gameboard-ui/src/styles.scss
@@ -107,6 +107,12 @@ h5 {
   font-weight: 300;
 }
 
+li {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+}
+
 .spacer {
   flex: 1;
 }


### PR DESCRIPTION
Players in PC4 voiced confusion about whether or not the "destroy VMs" button on the gameboard page was availab\le/working. Part of the problem was that there's no line break after the list of VMs, so challenges with a high number of VMs could push the button out of view.

The button is on a new line in 3.7.1.