### PR TITLE
Fix missing injector decoration for consoles

### DIFF
--- a/projects/gameboard-mks/src/app/clipboard.service.ts
+++ b/projects/gameboard-mks/src/app/clipboard.service.ts
@@ -4,7 +4,7 @@
 import { Inject, Injectable } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class ClipboardService {
 
     constructor(


### PR DESCRIPTION
Fixed an issue that caused topo consoles not to boot in Gameboard 3.7.1.