### PR TITLE
Error thrown on first user authentication

### DIFF
--- a/projects/gameboard-ui/src/app/components/sponsor-select-banner/sponsor-select-banner.component.ts
+++ b/projects/gameboard-ui/src/app/components/sponsor-select-banner/sponsor-select-banner.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Observable, map, tap } from 'rxjs';
+import { Observable, filter, map, tap } from 'rxjs';
 import { LogService } from '@/services/log.service';
 import { RouterService } from '@/services/router.service';
 import { ConfigService } from '@/utility/config.service';
@@ -42,7 +42,8 @@ export class SponsorSelectBannerComponent {
     this.sponsor$ = localUserService
       .user$
       .pipe(
-        map(u => u?.sponsor)
+        map(u => u?.sponsor),
+        filter(s => !!s)
       );
   }
 }

--- a/projects/gameboard-ui/src/app/utility/auth.service.ts
+++ b/projects/gameboard-ui/src/app/utility/auth.service.ts
@@ -130,14 +130,7 @@ export class AuthService {
   }
 
   async externalLoginCallback(url?: string): Promise<User> {
-    const user = await this.mgr.signinRedirectCallback(url);
-
-    if (this.access_token()) {
-      // log the login event for the current user (we track date of last login and total login count)
-      await firstValueFrom(this.userService.updateLoginEvents());
-    }
-
-    return user;
+    return await this.mgr.signinRedirectCallback(url);
   }
 
   logout(): void {


### PR DESCRIPTION
- Resolved an issue that caused the web client to attempt to report a login event before the user's account was fully created.
- Resolved an issue that could cause the "select your sponsor" banner to become visible to unauthed users under certain types of error conditions